### PR TITLE
fix: maven properties and module exception for reflection

### DIFF
--- a/fastexcel-support/pom.xml
+++ b/fastexcel-support/pom.xml
@@ -16,7 +16,6 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jdk.version>1.8</jdk.version>
         <gpg.skip>true</gpg.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <maven.test.skip>true</maven.test.skip>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jdk.version>1.8</jdk.version>
+        <java.version>1.8</java.version>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
         <gpg.skip>true</gpg.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <maven.test.skip>true</maven.test.skip>
@@ -220,6 +222,11 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.3.0</version>
+                    <configuration>
+                        <argLine>
+                            --add-opens java.base/sun.reflect.annotation=ALL-UNNAMED
+                        </argLine>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -245,8 +252,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -222,9 +222,12 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.3.0</version>
+<!--                    please add below configuration if you are using JDK 9 or higher-->
 <!--                    <configuration>-->
 <!--                        <argLine>-->
-<!--                            &#45;&#45;add-opens java.base/sun.reflect.annotation=ALL-UNNAMED-->
+<!--                            &#45;&#45;add-opens=java.base/java.lang=ALL-UNNAMED-->
+<!--                            &#45;&#45;add-opens=java.base/java.util=ALL-UNNAMED-->
+<!--                            &#45;&#45;add-opens=java.base/sun.reflect.annotation=ALL-UNNAMED-->
 <!--                        </argLine>-->
 <!--                    </configuration>-->
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -222,11 +222,11 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.3.0</version>
-                    <configuration>
-                        <argLine>
-                            --add-opens java.base/sun.reflect.annotation=ALL-UNNAMED
-                        </argLine>
-                    </configuration>
+<!--                    <configuration>-->
+<!--                        <argLine>-->
+<!--                            &#45;&#45;add-opens java.base/sun.reflect.annotation=ALL-UNNAMED-->
+<!--                        </argLine>-->
+<!--                    </configuration>-->
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
1. change java version as default maven and spring format

As no usage of `jdk.version` in whole project, so remove and add new properties as traditional format

```
<java.version>1.8</java.version>
<maven.compiler.target>1.8</maven.compiler.target> 
<maven.compiler.source>1.8</maven.compiler.source>
```

reference:
#https://www.baeldung.com/maven-java-version

2. fix the issue while working above java 9+ as java module mechanism limited. Just find out same behavior in github action confugration, so set below as comment in post commit

Add --add-opens for specific package into maven-surefire-plugin

```
<configuration>
    <argLine>
        --add-opens=java.base/java.lang=ALL-UNNAMED 
        --add-opens=java.base/java.util=ALL-UNNAMED 
        --add-opens=java.base/sun.reflect.annotation=ALL-UNNAMED
    </argLine>
</configuration>
```
e.g.
perform the unit test including reflection under java 21

`mvn -Dtest=CacheDataTest test  -D maven.test.skip=false`

Before the change:
<img width="1733" alt="image" src="https://github.com/user-attachments/assets/35787350-b825-446b-b540-d7f9ddd90f8a" />

After the change:
<img width="819" alt="image" src="https://github.com/user-attachments/assets/e1a3e5a8-0ce0-41c4-8876-2acedf745fa5" />


reference:
--add-opens module/package=target-module(,target-module)* Updates module to open package to target-module, regardless of module declaration. 
#https://docs.oracle.com/en/java/javase/17/docs/specs/man/java.html