### PR TITLE
fix: unclose resource in temp write

### DIFF
--- a/fastexcel-test/src/test/java/cn/idev/excel/test/temp/write/TempWriteTest.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/temp/write/TempWriteTest.java
@@ -1,19 +1,12 @@
 package cn.idev.excel.test.temp.write;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.nio.file.Path;
-import java.util.HashMap;
-import java.util.Map;
-
 import cn.idev.excel.EasyExcel;
+import cn.idev.excel.support.cglib.beans.BeanMap;
 import cn.idev.excel.test.demo.read.CustomStringStringConverter;
+import cn.idev.excel.test.util.TestFileUtil;
 import cn.idev.excel.util.BeanMapUtils;
 import cn.idev.excel.util.FileUtils;
 import cn.idev.excel.util.ListUtils;
-import cn.idev.excel.test.util.TestFileUtil;
-import cn.idev.excel.support.cglib.beans.BeanMap;
-
 import lombok.extern.slf4j.Slf4j;
 import org.apache.poi.ss.usermodel.ClientAnchor;
 import org.apache.poi.ss.usermodel.CreationHelper;
@@ -27,6 +20,12 @@ import org.apache.poi.xssf.streaming.SXSSFWorkbook;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
 
 @Slf4j
 public class TempWriteTest {
@@ -88,59 +87,59 @@ public class TempWriteTest {
     @Test
     public void imageWritePoi(@TempDir Path tempDir) throws Exception {
         String file = tempDir.resolve(System.currentTimeMillis() + ".xlsx").toString();
-        SXSSFWorkbook workbook = new SXSSFWorkbook();
-        SXSSFSheet sheet = workbook.createSheet("测试");
-        CreationHelper helper = workbook.getCreationHelper();
-        SXSSFDrawing sxssfDrawin = sheet.createDrawingPatriarch();
+        try (SXSSFWorkbook workbook = new SXSSFWorkbook();
+             FileOutputStream fileOutputStream = new FileOutputStream(file);
+        ) {
+            SXSSFSheet sheet = workbook.createSheet("测试");
+            CreationHelper helper = workbook.getCreationHelper();
+            SXSSFDrawing sxssfDrawin = sheet.createDrawingPatriarch();
 
-        byte[] imagebyte = FileUtils.readFileToByteArray(new File("src/test/resources/converter/img.jpg"));
+            byte[] imagebyte = FileUtils.readFileToByteArray(new File("src/test/resources/converter/img.jpg"));
 
-        for (int i = 0; i < 1 * 10000; i++) {
-            SXSSFRow row = sheet.createRow(i);
-            SXSSFCell cell = row.createCell(0);
-            cell.setCellValue(i);
-            int pictureIdx = workbook.addPicture(imagebyte, Workbook.PICTURE_TYPE_JPEG);
-            ClientAnchor anchor = helper.createClientAnchor();
-            anchor.setCol1(0);
-            anchor.setRow1(i);
-            // 插入图片
-            Picture pict = sxssfDrawin.createPicture(anchor, pictureIdx);
-            pict.resize();
-            log.info("新增行:{}", i);
+            for (int i = 0; i < 1 * 10000; i++) {
+                SXSSFRow row = sheet.createRow(i);
+                SXSSFCell cell = row.createCell(0);
+                cell.setCellValue(i);
+                int pictureIdx = workbook.addPicture(imagebyte, Workbook.PICTURE_TYPE_JPEG);
+                ClientAnchor anchor = helper.createClientAnchor();
+                anchor.setCol1(0);
+                anchor.setRow1(i);
+                // 插入图片
+                Picture pict = sxssfDrawin.createPicture(anchor, pictureIdx);
+                pict.resize();
+                log.info("新增行:{}", i);
+            }
+            workbook.write(fileOutputStream);
         }
-        FileOutputStream fileOutputStream = new FileOutputStream(file);
-        workbook.write(fileOutputStream);
-        fileOutputStream.flush();
-        workbook.close();
     }
 
     @Test
     public void tep(@TempDir Path tempDir) throws Exception {
         String file = tempDir.resolve(System.currentTimeMillis() + ".xlsx").toString();
-        SXSSFWorkbook workbook = new SXSSFWorkbook();
-        SXSSFSheet sheet = workbook.createSheet("测试");
-        CreationHelper helper = workbook.getCreationHelper();
-        SXSSFDrawing sxssfDrawin = sheet.createDrawingPatriarch();
+        try (SXSSFWorkbook workbook = new SXSSFWorkbook();
+             FileOutputStream fileOutputStream = new FileOutputStream(file);
+        ) {
+            SXSSFSheet sheet = workbook.createSheet("测试");
+            CreationHelper helper = workbook.getCreationHelper();
+            SXSSFDrawing sxssfDrawin = sheet.createDrawingPatriarch();
 
-        byte[] imagebyte = FileUtils.readFileToByteArray(new File("src/test/resources/converter/img.jpg"));
+            byte[] imagebyte = FileUtils.readFileToByteArray(new File("src/test/resources/converter/img.jpg"));
 
-        for (int i = 0; i < 1 * 10000; i++) {
-            SXSSFRow row = sheet.createRow(i);
-            SXSSFCell cell = row.createCell(0);
-            cell.setCellValue(i);
-            int pictureIdx = workbook.addPicture(imagebyte, Workbook.PICTURE_TYPE_JPEG);
-            ClientAnchor anchor = helper.createClientAnchor();
-            anchor.setCol1(0);
-            anchor.setRow1(i);
-            // 插入图片
-            Picture pict = sxssfDrawin.createPicture(anchor, pictureIdx);
-            pict.resize();
-            log.info("新增行:{}", i);
+            for (int i = 0; i < 1 * 10000; i++) {
+                SXSSFRow row = sheet.createRow(i);
+                SXSSFCell cell = row.createCell(0);
+                cell.setCellValue(i);
+                int pictureIdx = workbook.addPicture(imagebyte, Workbook.PICTURE_TYPE_JPEG);
+                ClientAnchor anchor = helper.createClientAnchor();
+                anchor.setCol1(0);
+                anchor.setRow1(i);
+                // 插入图片
+                Picture pict = sxssfDrawin.createPicture(anchor, pictureIdx);
+                pict.resize();
+                log.info("新增行:{}", i);
+            }
+            workbook.write(fileOutputStream);
         }
-        FileOutputStream fileOutputStream = new FileOutputStream(file);
-        workbook.write(fileOutputStream);
-        fileOutputStream.flush();
-        workbook.close();
     }
 
     @Test


### PR DESCRIPTION
Add try catch resources for tep and imageWritePoi. 
No update on large as OOM locally.

Before the change:
<img width="1449" alt="image" src="https://github.com/user-attachments/assets/394fb7e3-4f38-4ea5-a756-32931229ac42" />


Post the change:
<img width="841" alt="image" src="https://github.com/user-attachments/assets/dd517efd-2592-48dc-bb76-c9b86449a8bb" />
