### PR TITLE
fix: update custom converter map key generation

### DIFF
--- a/fastexcel-core/src/main/java/cn/idev/excel/write/metadata/holder/AbstractWriteHolder.java
+++ b/fastexcel-core/src/main/java/cn/idev/excel/write/metadata/holder/AbstractWriteHolder.java
@@ -230,7 +230,9 @@ public abstract class AbstractWriteHolder extends AbstractHolder implements Writ
         if (writeBasicParameter.getCustomConverterList() != null
             && !writeBasicParameter.getCustomConverterList().isEmpty()) {
             for (Converter<?> converter : writeBasicParameter.getCustomConverterList()) {
-                getConverterMap().put(ConverterKeyBuild.buildKey(converter.supportJavaTypeKey()), converter);
+                getConverterMap().put(
+                    ConverterKeyBuild.buildKey(converter.supportJavaTypeKey(), converter.supportExcelTypeKey()),
+                    converter);
             }
         }
     }

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/core/converter/CustomConverterTest.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/core/converter/CustomConverterTest.java
@@ -1,0 +1,85 @@
+package cn.idev.excel.test.core.converter;
+
+import cn.idev.excel.ExcelWriter;
+import cn.idev.excel.FastExcel;
+import cn.idev.excel.converters.Converter;
+import cn.idev.excel.converters.ConverterKeyBuild;
+import cn.idev.excel.test.util.TestFileUtil;
+import cn.idev.excel.write.builder.ExcelWriterSheetBuilder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.io.File;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@TestMethodOrder(MethodOrderer.MethodName.class)
+public class CustomConverterTest {
+
+    private static File converterCsvFile10;
+    private static File converterExcelFile11;
+    private static File converterExcelFile12;
+
+    @BeforeAll
+    static void init() {
+        converterCsvFile10 = TestFileUtil.createNewFile("converter10.csv");
+        converterExcelFile11 = TestFileUtil.createNewFile("converter11.xls");
+        converterExcelFile12 = TestFileUtil.createNewFile("converter12.xlsx");
+    }
+
+    @Test
+    void t01ConverterMapTest() throws Exception {
+        TimestampStringConverter timestampStringConverter = new TimestampStringConverter();
+        TimestampNumberConverter timestampNumberConverter = new TimestampNumberConverter();
+        ExcelWriter excelWriter = FastExcel.write(converterCsvFile10)
+            .registerConverter(timestampStringConverter)
+            .registerConverter(timestampNumberConverter)
+            .build();
+        Map<ConverterKeyBuild.ConverterKey, Converter<?>> converterMap = excelWriter.writeContext()
+            .currentWriteHolder().converterMap();
+        excelWriter.write(data(), new ExcelWriterSheetBuilder().sheetNo(0).build());
+        excelWriter.finish();
+        Assertions.assertTrue(converterMap.containsKey(ConverterKeyBuild
+            .buildKey(timestampStringConverter.supportJavaTypeKey(), timestampStringConverter.supportExcelTypeKey())));
+        Assertions.assertTrue(converterMap.containsKey(ConverterKeyBuild
+            .buildKey(timestampNumberConverter.supportJavaTypeKey(), timestampNumberConverter.supportExcelTypeKey())));
+    }
+
+    @Test
+    void t02Write10() throws Exception {
+        writeFile(converterCsvFile10);
+    }
+
+    @Test
+    void t03Write11() throws Exception {
+        writeFile(converterExcelFile11);
+    }
+
+    @Test
+    void t04Write12() throws Exception {
+        writeFile(converterExcelFile12);
+    }
+
+    private void writeFile(File file) throws Exception {
+        FastExcel.write(file)
+            .registerConverter(new TimestampNumberConverter())
+            .registerConverter(new TimestampStringConverter())
+            .sheet()
+            .doWrite(data());
+    }
+
+    private List<CustomConverterWriteData> data() throws Exception {
+        List<CustomConverterWriteData> list = new ArrayList<>();
+        CustomConverterWriteData writeData = new CustomConverterWriteData();
+        writeData.setTimestampStringData(Timestamp.valueOf("2020-01-01 01:00:00"));
+        writeData.setTimestampNumberData(Timestamp.valueOf("2020-12-01 12:12:12"));
+        list.add(writeData);
+        return list;
+    }
+
+}

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/core/converter/CustomConverterWriteData.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/core/converter/CustomConverterWriteData.java
@@ -1,0 +1,18 @@
+package cn.idev.excel.test.core.converter;
+
+import cn.idev.excel.annotation.ExcelProperty;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.sql.Timestamp;
+
+@Getter
+@Setter
+@EqualsAndHashCode
+public class CustomConverterWriteData {
+    @ExcelProperty(value = "时间戳-字符串", converter = TimestampStringConverter.class)
+    private Timestamp timestampStringData;
+    @ExcelProperty(value = "时间戳-数字", converter = TimestampNumberConverter.class)
+    private Timestamp timestampNumberData;
+}

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/core/converter/TimestampNumberConverter.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/core/converter/TimestampNumberConverter.java
@@ -1,0 +1,35 @@
+package cn.idev.excel.test.core.converter;
+
+import cn.idev.excel.converters.Converter;
+import cn.idev.excel.enums.CellDataTypeEnum;
+import cn.idev.excel.metadata.GlobalConfiguration;
+import cn.idev.excel.metadata.data.WriteCellData;
+import cn.idev.excel.metadata.property.ExcelContentProperty;
+import org.apache.poi.ss.usermodel.DateUtil;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+
+public class TimestampNumberConverter implements Converter<Timestamp> {
+    @Override
+    public Class<Timestamp> supportJavaTypeKey() {
+        return Timestamp.class;
+    }
+
+    @Override
+    public CellDataTypeEnum supportExcelTypeKey() {
+        return CellDataTypeEnum.NUMBER;
+    }
+
+    @Override
+    public WriteCellData<?> convertToExcelData(Timestamp value, ExcelContentProperty contentProperty,
+                                               GlobalConfiguration globalConfiguration) {
+        if (contentProperty == null || contentProperty.getDateTimeFormatProperty() == null) {
+            return new WriteCellData<>(
+                BigDecimal.valueOf(DateUtil.getExcelDate(value, globalConfiguration.getUse1904windowing())));
+        } else {
+            return new WriteCellData<>(
+                BigDecimal.valueOf(DateUtil.getExcelDate(value, contentProperty.getDateTimeFormatProperty().getUse1904windowing())));
+        }
+    }
+}

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/core/converter/TimestampStringConverter.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/core/converter/TimestampStringConverter.java
@@ -1,0 +1,39 @@
+package cn.idev.excel.test.core.converter;
+
+import cn.idev.excel.converters.Converter;
+import cn.idev.excel.enums.CellDataTypeEnum;
+import cn.idev.excel.metadata.GlobalConfiguration;
+import cn.idev.excel.metadata.data.WriteCellData;
+import cn.idev.excel.metadata.property.ExcelContentProperty;
+import cn.idev.excel.util.DateUtils;
+
+import java.sql.Timestamp;
+
+public class TimestampStringConverter implements Converter<Timestamp> {
+    @Override
+    public Class<Timestamp> supportJavaTypeKey() {
+        return Timestamp.class;
+    }
+
+    @Override
+    public CellDataTypeEnum supportExcelTypeKey() {
+        return CellDataTypeEnum.STRING;
+    }
+
+    @Override
+    public WriteCellData<?> convertToExcelData(Timestamp value, ExcelContentProperty contentProperty,
+                                               GlobalConfiguration globalConfiguration) {
+        WriteCellData<String> cellData = new WriteCellData<>();
+        String cellValue;
+        if (contentProperty == null || contentProperty.getDateTimeFormatProperty() == null) {
+            cellValue = DateUtils.format(value.toLocalDateTime(), null, globalConfiguration.getLocale());
+        } else {
+            cellValue = DateUtils.format(value.toLocalDateTime(), contentProperty.getDateTimeFormatProperty().getFormat(),
+                globalConfiguration.getLocale());
+        }
+        cellData.setType(CellDataTypeEnum.STRING);
+        cellData.setStringValue(cellValue);
+        cellData.setData(cellValue);
+        return cellData;
+    }
+}


### PR DESCRIPTION
重新提交`PR`，fixed https://github.com/fast-excel/fastexcel/issues/170
- 修复导出Excel时，使用 `registerConverter`方法全局添加自定义`Converter`失效的问题
- 增加自定义`Converter`测试用例