### PR TITLE
dependency: update dependencies and remove exclusions

### DIFF
--- a/fastexcel-core/pom.xml
+++ b/fastexcel-core/pom.xml
@@ -18,46 +18,22 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-csv</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-io</groupId>
-                    <artifactId>commons-io</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>commons-codec</groupId>
-                    <artifactId>commons-codec</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-io</groupId>
-                    <artifactId>commons-io</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
-
         <dependency>
             <groupId>org.ehcache</groupId>
             <artifactId>ehcache</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-
-        <!-- provided -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -32,11 +32,11 @@
         <gpg.skip>true</gpg.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <maven.test.skip>true</maven.test.skip>
-        <commons-csv.version>1.11.0</commons-csv.version>
+        <commons-csv.version>1.14.0</commons-csv.version>
         <poi.version>5.4.1</poi.version>
         <poi-ooxml.version>5.4.1</poi-ooxml.version>
         <ehcache.version>3.9.11</ehcache.version>
-        <commons-io.version>2.16.1</commons-io.version>
+        <commons-io.version>2.18.0</commons-io.version>
         <slf4j-api.version>1.7.36</slf4j-api.version>
         <lombok.version>1.18.32</lombok.version>
         <spring-core.version>5.3.37</spring-core.version>
@@ -103,16 +103,6 @@
                 <groupId>org.apache.poi</groupId>
                 <artifactId>poi</artifactId>
                 <version>${poi.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>commons-io</groupId>
-                        <artifactId>commons-io</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>commons-codec</groupId>
-                        <artifactId>commons-codec</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.poi</groupId>
@@ -120,8 +110,8 @@
                 <version>${poi-ooxml.version}</version>
                 <exclusions>
                     <exclusion>
-                        <groupId>commons-io</groupId>
-                        <artifactId>commons-io</artifactId>
+                        <artifactId>commons-codec</artifactId>
+                        <groupId>commons-codec</groupId>
                     </exclusion>
                 </exclusions>
             </dependency>


### PR DESCRIPTION
IMO,after upgraded POI version to 5.4.1,we can deal with dependency conflicts without using exclusions

## What's changed?

- **commons-csv**: upgrade from 1.11.0 to 1.14.0
- **commons-io**: upgrade from 2.16.1 to 2.18.0
- remove exclusions for commons-io and commons-codec from poi and poi-ooxml dependencies
- update poi and poi-ooxml exclusions in root pom.xml
