### PR TITLE
feat: enable all verification in ci

### DIFF
--- a/fastexcel-test/pom.xml
+++ b/fastexcel-test/pom.xml
@@ -71,7 +71,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <includes>
-                        <include>/cn/idev/excel/test/core/**/*.java</include>
+                        <include>/cn/idev/excel/test/**/*.java</include>
                     </includes>
                     <testFailureIgnore>false</testFailureIgnore>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <gpg.skip>true</gpg.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>
-        <maven.test.skip>true</maven.test.skip>
+        <maven.test.skip>false</maven.test.skip>
         <commons-csv.version>1.11.0</commons-csv.version>
         <poi.version>5.4.1</poi.version>
         <poi-ooxml.version>5.4.1</poi-ooxml.version>


### PR DESCRIPTION
As #372 mentioned, all case could be passed now, so how about to enable the forced CI verification.

1. change default maven.test.skip to false
2. change surefire scope for all test as /cn/idev/excel/test/**/*.java