### PR TITLE
feat: add WriteSheetWorkbookWriteHandler to set the order of sheets

### DIFF
--- a/fastexcel-core/src/main/java/cn/idev/excel/constant/OrderConstant.java
+++ b/fastexcel-core/src/main/java/cn/idev/excel/constant/OrderConstant.java
@@ -31,4 +31,9 @@ public class OrderConstant {
      * Sorting of styles written to cells.
      */
     public static int FILL_STYLE = 50000;
+
+    /**
+     * Sorting of sheets
+     */
+    public static int SHEET_ORDER = 60000;
 }

--- a/fastexcel-core/src/main/java/cn/idev/excel/write/handler/DefaultWriteHandlerLoader.java
+++ b/fastexcel-core/src/main/java/cn/idev/excel/write/handler/DefaultWriteHandlerLoader.java
@@ -1,13 +1,14 @@
 package cn.idev.excel.write.handler;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import cn.idev.excel.support.ExcelTypeEnum;
 import cn.idev.excel.write.handler.impl.DefaultRowWriteHandler;
 import cn.idev.excel.write.handler.impl.DimensionWorkbookWriteHandler;
 import cn.idev.excel.write.handler.impl.FillStyleCellWriteHandler;
+import cn.idev.excel.write.handler.impl.WriteSheetWorkbookWriteHandler;
 import cn.idev.excel.write.style.DefaultStyle;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Load default handler
@@ -36,6 +37,7 @@ public class DefaultWriteHandlerLoader {
                 handlerList.add(new DimensionWorkbookWriteHandler());
                 handlerList.add(new DefaultRowWriteHandler());
                 handlerList.add(new FillStyleCellWriteHandler());
+                handlerList.add(new WriteSheetWorkbookWriteHandler());
                 if (useDefaultStyle) {
                     handlerList.add(new DefaultStyle());
                 }
@@ -43,6 +45,7 @@ public class DefaultWriteHandlerLoader {
             case XLS:
                 handlerList.add(new DefaultRowWriteHandler());
                 handlerList.add(new FillStyleCellWriteHandler());
+                handlerList.add(new WriteSheetWorkbookWriteHandler());
                 if (useDefaultStyle) {
                     handlerList.add(new DefaultStyle());
                 }

--- a/fastexcel-core/src/main/java/cn/idev/excel/write/handler/impl/WriteSheetWorkbookWriteHandler.java
+++ b/fastexcel-core/src/main/java/cn/idev/excel/write/handler/impl/WriteSheetWorkbookWriteHandler.java
@@ -1,0 +1,52 @@
+package cn.idev.excel.write.handler.impl;
+
+import cn.idev.excel.constant.OrderConstant;
+import cn.idev.excel.util.StringUtils;
+import cn.idev.excel.write.handler.WorkbookWriteHandler;
+import cn.idev.excel.write.metadata.holder.WriteSheetHolder;
+import cn.idev.excel.write.metadata.holder.WriteWorkbookHolder;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.poi.ss.usermodel.Workbook;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Set the order of each worksheet after completing workbook processing.
+ */
+public class WriteSheetWorkbookWriteHandler implements WorkbookWriteHandler {
+
+    @Override
+    public int order() {
+        return OrderConstant.SHEET_ORDER;
+    }
+
+    @Override
+    public void afterWorkbookDispose(WriteWorkbookHolder writeWorkbookHolder) {
+        if (writeWorkbookHolder == null || writeWorkbookHolder.getWorkbook() == null) {
+            return;
+        }
+        Map<Integer, WriteSheetHolder> writeSheetHolderMap = writeWorkbookHolder.getHasBeenInitializedSheetIndexMap();
+        if (MapUtils.isEmpty(writeSheetHolderMap)) {
+            return;
+        }
+        Workbook workbook = writeWorkbookHolder.getWorkbook();
+        // sort by sheetNo.
+        ArrayList<Integer> sheetNoSortList = new ArrayList<>(writeSheetHolderMap.keySet());
+        Collections.sort(sheetNoSortList);
+
+        int pos = 0;
+        for (Integer key : sheetNoSortList) {
+            WriteSheetHolder writeSheetHolder = writeSheetHolderMap.get(key);
+            if (writeSheetHolder == null
+                || writeSheetHolder.getWriteSheet() == null
+                || writeSheetHolder.getSheetNo() == null
+                || StringUtils.isBlank(writeSheetHolder.getSheetName())) {
+                continue;
+            }
+            // set the order of sheet.
+            workbook.setSheetOrder(writeSheetHolder.getSheetName(), pos++);
+        }
+    }
+}

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/core/writesheet/WriteSheetData.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/core/writesheet/WriteSheetData.java
@@ -1,0 +1,14 @@
+package cn.idev.excel.test.core.writesheet;
+
+import cn.idev.excel.annotation.ExcelProperty;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode
+public class WriteSheetData {
+    @ExcelProperty("字符串标题")
+    private String string;
+}

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/core/writesheet/WriteSheetTest.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/core/writesheet/WriteSheetTest.java
@@ -1,0 +1,90 @@
+package cn.idev.excel.test.core.writesheet;
+
+import cn.idev.excel.ExcelWriter;
+import cn.idev.excel.FastExcel;
+import cn.idev.excel.support.ExcelTypeEnum;
+import cn.idev.excel.test.util.TestFileUtil;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class WriteSheetTest {
+
+    @Test
+    public void testSheetOrder03() {
+        // normal
+        testSheetOrderInternal(ExcelTypeEnum.XLS, Arrays.asList(0));
+        testSheetOrderInternal(ExcelTypeEnum.XLS, Arrays.asList(0, 1, 2));
+        // sheetNo is bigger than the size of workbook sheet num
+        testSheetOrderInternal(ExcelTypeEnum.XLS, Arrays.asList(2));
+        testSheetOrderInternal(ExcelTypeEnum.XLS, Arrays.asList(10, 6, 8));
+        // negative numbers
+        testSheetOrderInternal(ExcelTypeEnum.XLS, Arrays.asList(-1));
+        testSheetOrderInternal(ExcelTypeEnum.XLS, Arrays.asList(-8, -10, -6));
+        testSheetOrderInternal(ExcelTypeEnum.XLS, Arrays.asList(-8, 6));
+    }
+
+    @Test
+    public void testSheetOrder07() {
+        // normal
+        testSheetOrderInternal(ExcelTypeEnum.XLSX, Arrays.asList(0));
+        testSheetOrderInternal(ExcelTypeEnum.XLSX, Arrays.asList(0, 1, 2));
+        // sheetNo is bigger than the size of workbook sheet num
+        testSheetOrderInternal(ExcelTypeEnum.XLSX, Arrays.asList(2));
+        testSheetOrderInternal(ExcelTypeEnum.XLSX, Arrays.asList(10, 6, 8));
+        // negative numbers
+        testSheetOrderInternal(ExcelTypeEnum.XLSX, Arrays.asList(-1));
+        testSheetOrderInternal(ExcelTypeEnum.XLSX, Arrays.asList(-8, -10, -6));
+        testSheetOrderInternal(ExcelTypeEnum.XLSX, Arrays.asList(-8, 6));
+    }
+
+    private void testSheetOrderInternal(ExcelTypeEnum excelTypeEnum, List<Integer> sheetNoList) {
+        Map<Integer, Integer> dataMap = initSheetDataSizeList(sheetNoList);
+
+        File testFile = TestFileUtil.createNewFile("writesheet/write-sheet-order" + excelTypeEnum.getValue());
+        // write a file in the order of sheetNoList.
+        try (ExcelWriter excelWriter = FastExcel.write(testFile, WriteSheetData.class).excelType(excelTypeEnum).build()) {
+            for (Integer sheetNo : sheetNoList) {
+                excelWriter.write(dataList(dataMap.get(sheetNo)), FastExcel.writerSheet(sheetNo).build());
+            }
+        }
+
+        for (int i = 0; i < sheetNoList.size(); i++) {
+            List<WriteSheetData> sheetDataList = FastExcel.read(testFile)
+                .excelType(excelTypeEnum)
+                .head(WriteSheetData.class)
+                .sheet(i)
+                .doReadSync();
+            Assertions.assertEquals(dataMap.get(sheetNoList.get(i)), sheetDataList.size());
+        }
+    }
+
+    private Map<Integer, Integer> initSheetDataSizeList(List<Integer> sheetNoList) {
+        // sort by sheetNo
+        Collections.sort(sheetNoList);
+        // key: sheetNo
+        // value: data size
+        Map<Integer, Integer> dataMap = new HashMap<>();
+        for (int i = 0; i < sheetNoList.size(); i++) {
+            dataMap.put(sheetNoList.get(i), i + 1);
+        }
+        return dataMap;
+    }
+
+    private static List<WriteSheetData> dataList(int size) {
+        List<WriteSheetData> dataList = new ArrayList<>();
+        for (int i = 0; i < size; i++) {
+            WriteSheetData data = new WriteSheetData();
+            data.setString("String" + i);
+            dataList.add(data);
+        }
+        return dataList;
+    }
+}


### PR DESCRIPTION
## Purpose of the pull request

Closed: #409 

## What's changed?
- Add `WriteSheetWorkbookWriteHandler` in DefaultWriteHandlerLoader#loadDefaultHandler() for xls and xlsx type.
- use the `Workbook#setSheetOrder()` method in the `WriteSheetWorkbookWriteHandler#afterWorkbookDispose()` method to sort according to the sheetNo value.

## Checklist

- [x] I have written the necessary doc or comment.
- [x] I have added the necessary unit tests and all cases have passed.