### PR TITLE
optimize this by standardizing on the @Slf4j annotation from Lombok for all logging operations

### DIFF
--- a/fastexcel-test/src/test/java/cn/idev/excel/test/core/annotation/AnnotationDataListener.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/core/annotation/AnnotationDataListener.java
@@ -8,15 +8,14 @@ import com.alibaba.fastjson2.JSON;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  *
  */
+@Slf4j
 public class AnnotationDataListener extends AnalysisEventListener<AnnotationData> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(AnnotationDataListener.class);
     List<AnnotationData> list = new ArrayList<AnnotationData>();
 
     @Override
@@ -34,6 +33,6 @@ public class AnnotationDataListener extends AnalysisEventListener<AnnotationData
             throw new ExcelCommonException("Test Exception", e);
         }
         Assertions.assertEquals(data.getNumber(), 99.99, 0.00);
-        LOGGER.debug("First row:{}", JSON.toJSONString(list.get(0)));
+        log.debug("First row:{}", JSON.toJSONString(list.get(0)));
     }
 }

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/core/annotation/AnnotationIndexAndNameDataListener.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/core/annotation/AnnotationIndexAndNameDataListener.java
@@ -5,15 +5,15 @@ import cn.idev.excel.event.AnalysisEventListener;
 import com.alibaba.fastjson2.JSON;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  *
  */
+@Slf4j
 public class AnnotationIndexAndNameDataListener extends AnalysisEventListener<AnnotationIndexAndNameData> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(AnnotationIndexAndNameDataListener.class);
+
     List<AnnotationIndexAndNameData> list = new ArrayList<AnnotationIndexAndNameData>();
 
     @Override
@@ -29,6 +29,6 @@ public class AnnotationIndexAndNameDataListener extends AnalysisEventListener<An
         Assertions.assertEquals(data.getIndex1(), "第1个");
         Assertions.assertEquals(data.getIndex2(), "第2个");
         Assertions.assertEquals(data.getIndex4(), "第4个");
-        LOGGER.debug("First row:{}", JSON.toJSONString(list.get(0)));
+        log.debug("First row:{}", JSON.toJSONString(list.get(0)));
     }
 }

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/core/celldata/CellDataDataListener.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/core/celldata/CellDataDataListener.java
@@ -6,15 +6,15 @@ import cn.idev.excel.support.ExcelTypeEnum;
 import com.alibaba.fastjson2.JSON;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  *
  */
+@Slf4j
 public class CellDataDataListener extends AnalysisEventListener<CellDataReadData> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(CellDataDataListener.class);
+
     List<CellDataReadData> list = new ArrayList<>();
 
     @Override
@@ -36,6 +36,6 @@ public class CellDataDataListener extends AnalysisEventListener<CellDataReadData
         } else {
             Assertions.assertNull(cellDataData.getFormulaValue().getData());
         }
-        LOGGER.debug("First row:{}", JSON.toJSONString(list.get(0)));
+        log.debug("First row:{}", JSON.toJSONString(list.get(0)));
     }
 }

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/core/converter/ConverterDataListener.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/core/converter/ConverterDataListener.java
@@ -8,15 +8,14 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  *
  */
+@Slf4j
 public class ConverterDataListener extends AnalysisEventListener<ConverterReadData> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ConverterDataListener.class);
     private final List<ConverterReadData> list = new ArrayList<>();
 
     @Override
@@ -42,6 +41,6 @@ public class ConverterDataListener extends AnalysisEventListener<ConverterReadDa
         Assertions.assertEquals(data.getFloatData(), (float) 1.0, 0.0);
         Assertions.assertEquals(data.getString(), "测试");
         Assertions.assertEquals(data.getCellData().getStringValue(), "自定义");
-        LOGGER.debug("First row:{}", JSON.toJSONString(list.get(0)));
+        log.debug("First row:{}", JSON.toJSONString(list.get(0)));
     }
 }

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/core/converter/ReadAllConverterDataListener.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/core/converter/ReadAllConverterDataListener.java
@@ -11,15 +11,14 @@ import java.math.BigInteger;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  *
  */
+@Slf4j
 public class ReadAllConverterDataListener extends AnalysisEventListener<ReadAllConverterData> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ReadAllConverterDataListener.class);
     List<ReadAllConverterData> list = new ArrayList<ReadAllConverterData>();
 
     @Override
@@ -79,6 +78,6 @@ public class ReadAllConverterDataListener extends AnalysisEventListener<ReadAllC
         double doubleStringFormulaNumber = new BigDecimal(data.getStringFormulaNumber()).doubleValue();
         Assertions.assertEquals(doubleStringFormulaNumber, 2.0, 0.0);
         Assertions.assertEquals(data.getStringFormulaString(), "1测试");
-        LOGGER.debug("First row:{}", JSON.toJSONString(list.get(0)));
+        log.debug("First row:{}", JSON.toJSONString(list.get(0)));
     }
 }

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/core/exception/ExceptionDataListener.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/core/exception/ExceptionDataListener.java
@@ -5,20 +5,19 @@ import cn.idev.excel.event.AnalysisEventListener;
 import com.alibaba.fastjson2.JSON;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  *
  */
+@Slf4j
 public class ExceptionDataListener extends AnalysisEventListener<ExceptionData> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ExceptionData.class);
     List<ExceptionData> list = new ArrayList<ExceptionData>();
 
     @Override
     public void onException(Exception exception, AnalysisContext context) {
-        LOGGER.info("抛出异常,忽略：{}", exception.getMessage(), exception);
+        log.info("抛出异常,忽略：{}", exception.getMessage(), exception);
     }
 
     @Override
@@ -47,6 +46,6 @@ public class ExceptionDataListener extends AnalysisEventListener<ExceptionData> 
                         .getHeadNameList()
                         .get(0),
                 "姓名");
-        LOGGER.debug("First row:{}", JSON.toJSONString(list.get(0)));
+        log.debug("First row:{}", JSON.toJSONString(list.get(0)));
     }
 }

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/core/exception/ExceptionThrowDataListener.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/core/exception/ExceptionThrowDataListener.java
@@ -4,14 +4,14 @@ import cn.idev.excel.context.AnalysisContext;
 import cn.idev.excel.read.listener.ReadListener;
 import java.util.ArrayList;
 import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  *
  */
+@Slf4j
 public class ExceptionThrowDataListener implements ReadListener<ExceptionData> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ExceptionData.class);
+
     List<ExceptionData> list = new ArrayList<ExceptionData>();
 
     @Override

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/core/extra/ExtraDataListener.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/core/extra/ExtraDataListener.java
@@ -4,15 +4,14 @@ import cn.idev.excel.context.AnalysisContext;
 import cn.idev.excel.event.AnalysisEventListener;
 import cn.idev.excel.metadata.CellExtra;
 import com.alibaba.fastjson2.JSON;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  *
  */
+@Slf4j
 public class ExtraDataListener extends AnalysisEventListener<ExtraData> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ExtraData.class);
 
     @Override
     public void invoke(ExtraData data, AnalysisContext context) {}
@@ -22,7 +21,7 @@ public class ExtraDataListener extends AnalysisEventListener<ExtraData> {
 
     @Override
     public void extra(CellExtra extra, AnalysisContext context) {
-        LOGGER.info("extra data:{}", JSON.toJSONString(extra));
+        log.info("extra data:{}", JSON.toJSONString(extra));
         switch (extra.getType()) {
             case COMMENT:
                 Assertions.assertEquals("批注的内容", extra.getText());

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/core/extra/ExtraDataTest.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/core/extra/ExtraDataTest.java
@@ -8,17 +8,16 @@ import cn.idev.excel.read.listener.ReadListener;
 import cn.idev.excel.test.util.TestFileUtil;
 import com.alibaba.fastjson2.JSON;
 import java.io.File;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  *
  */
+@Slf4j
 public class ExtraDataTest {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ExtraDataTest.class);
     private static File file03;
     private static File file07;
 
@@ -52,7 +51,7 @@ public class ExtraDataTest {
 
                     @Override
                     public void extra(CellExtra extra, AnalysisContext context) {
-                        LOGGER.info("extra data:{}", JSON.toJSONString(extra));
+                        log.info("extra data:{}", JSON.toJSONString(extra));
                         switch (extra.getType()) {
                             case HYPERLINK:
                                 if ("222222222".equals(extra.getText())) {

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/core/head/ComplexDataListener.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/core/head/ComplexDataListener.java
@@ -5,15 +5,15 @@ import cn.idev.excel.event.AnalysisEventListener;
 import com.alibaba.fastjson2.JSON;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  *
  */
+@Slf4j
 public class ComplexDataListener extends AnalysisEventListener<ComplexHeadData> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ComplexHeadData.class);
+
     List<ComplexHeadData> list = new ArrayList<ComplexHeadData>();
 
     @Override
@@ -26,6 +26,6 @@ public class ComplexDataListener extends AnalysisEventListener<ComplexHeadData> 
         Assertions.assertEquals(list.size(), 1);
         ComplexHeadData data = list.get(0);
         Assertions.assertEquals(data.getString4(), "字符串4");
-        LOGGER.debug("First row:{}", JSON.toJSONString(list.get(0)));
+        log.debug("First row:{}", JSON.toJSONString(list.get(0)));
     }
 }

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/core/head/ListHeadDataListener.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/core/head/ListHeadDataListener.java
@@ -7,16 +7,15 @@ import com.alibaba.fastjson2.JSON;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  *
  */
+@Slf4j
 public class ListHeadDataListener implements ReadListener<Map<Integer, String>> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(NoHeadData.class);
     List<Map<Integer, String>> list = new ArrayList<Map<Integer, String>>();
 
     @Override
@@ -41,6 +40,6 @@ public class ListHeadDataListener implements ReadListener<Map<Integer, String>> 
         Assertions.assertEquals("1", data.get(1));
         Assertions.assertEquals("2020-01-01 01:01:01", data.get(2));
         Assertions.assertEquals("额外数据", data.get(3));
-        LOGGER.debug("First row:{}", JSON.toJSONString(list.get(0)));
+        log.debug("First row:{}", JSON.toJSONString(list.get(0)));
     }
 }

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/core/head/MaxHeadReadListener.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/core/head/MaxHeadReadListener.java
@@ -8,11 +8,11 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class MaxHeadReadListener extends AnalysisEventListener<Map<Integer, String>> {
-    private static final Logger log = LoggerFactory.getLogger(MaxHeadReadListener.class);
+
     List<Map<Integer, String>> list = new ArrayList<Map<Integer, String>>();
     private List<Map<Integer, String>> headList = new ArrayList<>();
     private Map<Integer, String> headTitleMap = new HashMap<>();

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/core/head/MaxHeadSizeTest.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/core/head/MaxHeadSizeTest.java
@@ -8,17 +8,16 @@ import com.alibaba.fastjson2.JSONWriter;
 import java.io.File;
 import java.util.List;
 import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @TestMethodOrder(MethodOrderer.MethodName.class)
+@Slf4j
 public class MaxHeadSizeTest {
-    private static final Logger log = LoggerFactory.getLogger(MaxHeadSizeTest.class);
 
     private static String headFile01;
     private static String headFile02;

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/core/head/NoHeadDataListener.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/core/head/NoHeadDataListener.java
@@ -5,15 +5,15 @@ import cn.idev.excel.event.AnalysisEventListener;
 import com.alibaba.fastjson2.JSON;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  *
  */
+@Slf4j
 public class NoHeadDataListener extends AnalysisEventListener<NoHeadData> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(NoHeadData.class);
+
     List<NoHeadData> list = new ArrayList<NoHeadData>();
 
     @Override
@@ -26,6 +26,6 @@ public class NoHeadDataListener extends AnalysisEventListener<NoHeadData> {
         Assertions.assertEquals(list.size(), 1);
         NoHeadData data = list.get(0);
         Assertions.assertEquals(data.getString(), "字符串0");
-        LOGGER.debug("First row:{}", JSON.toJSONString(list.get(0)));
+        log.debug("First row:{}", JSON.toJSONString(list.get(0)));
     }
 }

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/core/large/LargeDataListener.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/core/large/LargeDataListener.java
@@ -4,31 +4,30 @@ import cn.idev.excel.context.AnalysisContext;
 import cn.idev.excel.event.AnalysisEventListener;
 import cn.idev.excel.support.ExcelTypeEnum;
 import com.alibaba.fastjson2.JSON;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  *
  */
+@Slf4j
 public class LargeDataListener extends AnalysisEventListener<LargeData> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(LargeDataListener.class);
     private int count = 0;
 
     @Override
     public void invoke(LargeData data, AnalysisContext context) {
         if (count == 0) {
-            LOGGER.info("First row:{}", JSON.toJSONString(data));
+            log.info("First row:{}", JSON.toJSONString(data));
         }
         count++;
         if (count % 100000 == 0) {
-            LOGGER.info("Already read:{},{}", count, JSON.toJSONString(data));
+            log.info("Already read:{},{}", count, JSON.toJSONString(data));
         }
     }
 
     @Override
     public void doAfterAllAnalysed(AnalysisContext context) {
-        LOGGER.info("Large row count:{}", count);
+        log.info("Large row count:{}", count);
         if (context.readWorkbookHolder().getExcelType() != ExcelTypeEnum.CSV) {
             Assertions.assertEquals(count, 464509);
         } else {

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/core/large/LargeDataTest.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/core/large/LargeDataTest.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.poi.xssf.streaming.SXSSFCell;
 import org.apache.poi.xssf.streaming.SXSSFRow;
 import org.apache.poi.xssf.streaming.SXSSFSheet;
@@ -17,15 +18,14 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  *
  */
 @TestMethodOrder(MethodOrderer.MethodName.class)
+@Slf4j
 public class LargeDataTest {
-    private static final Logger LOGGER = LoggerFactory.getLogger(LargeDataTest.class);
+
     private static File fileFill07;
     private static File template07;
     private static File fileCsv;
@@ -55,7 +55,7 @@ public class LargeDataTest {
                 .headRowNumber(2)
                 .sheet()
                 .doRead();
-        LOGGER.info("Large data total time spent:{}", System.currentTimeMillis() - start);
+        log.info("Large data total time spent:{}", System.currentTimeMillis() - start);
     }
 
     @Test
@@ -65,7 +65,7 @@ public class LargeDataTest {
             WriteSheet writeSheet = EasyExcel.writerSheet().build();
             for (int j = 0; j < 5000; j++) {
                 excelWriter.fill(data(), writeSheet);
-                LOGGER.info("{} fill success.", j);
+                log.info("{} fill success.", j);
             }
         }
     }
@@ -78,17 +78,17 @@ public class LargeDataTest {
             WriteSheet writeSheet = EasyExcel.writerSheet().build();
             for (int j = 0; j < 5000; j++) {
                 excelWriter.write(data(), writeSheet);
-                LOGGER.info("{} write success.", j);
+                log.info("{} write success.", j);
             }
         }
-        LOGGER.info("CSV large data total time spent:{}", System.currentTimeMillis() - start);
+        log.info("CSV large data total time spent:{}", System.currentTimeMillis() - start);
 
         //  read
         start = System.currentTimeMillis();
         EasyExcel.read(fileCsv, LargeData.class, new LargeDataListener())
                 .sheet()
                 .doRead();
-        LOGGER.info("CSV large data total time spent:{}", System.currentTimeMillis() - start);
+        log.info("CSV large data total time spent:{}", System.currentTimeMillis() - start);
     }
 
     @Test
@@ -106,11 +106,11 @@ public class LargeDataTest {
         writeSheet = EasyExcel.writerSheet().build();
         for (int j = 0; j < 5000; j++) {
             excelWriter.write(data(), writeSheet);
-            LOGGER.info("{} write success.", j);
+            log.info("{} write success.", j);
         }
         excelWriter.finish();
         long cost = System.currentTimeMillis() - start;
-        LOGGER.info("write cost:{}", cost);
+        log.info("write cost:{}", cost);
         start = System.currentTimeMillis();
         try (FileOutputStream fileOutputStream = new FileOutputStream(fileWritePoi07)) {
             SXSSFWorkbook workbook = new SXSSFWorkbook();
@@ -122,7 +122,7 @@ public class LargeDataTest {
                     cell.setCellValue("str-" + j + "-" + i);
                 }
                 if (i % 5000 == 0) {
-                    LOGGER.info("{} write success.", i);
+                    log.info("{} write success.", i);
                 }
             }
             workbook.write(fileOutputStream);
@@ -130,8 +130,8 @@ public class LargeDataTest {
             workbook.close();
         }
         long costPoi = System.currentTimeMillis() - start;
-        LOGGER.info("poi write cost:{}", System.currentTimeMillis() - start);
-        LOGGER.info("{} vs {}", cost, costPoi);
+        log.info("poi write cost:{}", System.currentTimeMillis() - start);
+        log.info("{} vs {}", cost, costPoi);
         Assertions.assertTrue(costPoi * 2 > cost);
     }
 

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/core/multiplesheets/MultipleSheetsListener.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/core/multiplesheets/MultipleSheetsListener.java
@@ -5,15 +5,15 @@ import cn.idev.excel.event.AnalysisEventListener;
 import com.alibaba.fastjson2.JSON;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  *
  */
+@Slf4j
 public class MultipleSheetsListener extends AnalysisEventListener<MultipleSheetsData> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(MultipleSheetsListener.class);
+
     List<MultipleSheetsData> list = new ArrayList<MultipleSheetsData>();
 
     @Override
@@ -23,9 +23,9 @@ public class MultipleSheetsListener extends AnalysisEventListener<MultipleSheets
 
     @Override
     public void doAfterAllAnalysed(AnalysisContext context) {
-        LOGGER.debug("A form is read finished.");
+        log.debug("A form is read finished.");
         Assertions.assertEquals(list.get(0).getTitle(), "表1数据");
-        LOGGER.debug("All row:{}", JSON.toJSONString(list));
+        log.debug("All row:{}", JSON.toJSONString(list));
     }
 
     public List<MultipleSheetsData> getList() {

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/core/parameter/ParameterDataListener.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/core/parameter/ParameterDataListener.java
@@ -5,15 +5,15 @@ import cn.idev.excel.event.AnalysisEventListener;
 import com.alibaba.fastjson2.JSON;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  *
  */
+@Slf4j
 public class ParameterDataListener extends AnalysisEventListener<ParameterData> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ParameterDataListener.class);
+
     List<ParameterData> list = new ArrayList<ParameterData>();
 
     @Override
@@ -34,6 +34,6 @@ public class ParameterDataListener extends AnalysisEventListener<ParameterData> 
                         .getHeadNameList()
                         .get(0),
                 "姓名");
-        LOGGER.debug("First row:{}", JSON.toJSONString(list.get(0)));
+        log.debug("First row:{}", JSON.toJSONString(list.get(0)));
     }
 }

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/core/repetition/RepetitionDataListener.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/core/repetition/RepetitionDataListener.java
@@ -2,19 +2,18 @@ package cn.idev.excel.test.core.repetition;
 
 import cn.idev.excel.context.AnalysisContext;
 import cn.idev.excel.event.AnalysisEventListener;
-import cn.idev.excel.test.core.simple.SimpleDataListener;
 import com.alibaba.fastjson2.JSON;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  *
  */
+@Slf4j
 public class RepetitionDataListener extends AnalysisEventListener<RepetitionData> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(SimpleDataListener.class);
+
     List<RepetitionData> list = new ArrayList<RepetitionData>();
 
     @Override
@@ -27,6 +26,6 @@ public class RepetitionDataListener extends AnalysisEventListener<RepetitionData
         Assertions.assertEquals(list.size(), 2);
         Assertions.assertEquals(list.get(0).getString(), "字符串0");
         Assertions.assertEquals(list.get(1).getString(), "字符串0");
-        LOGGER.debug("First row:{}", JSON.toJSONString(list.get(0)));
+        log.debug("First row:{}", JSON.toJSONString(list.get(0)));
     }
 }

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/core/simple/SimpleDataListener.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/core/simple/SimpleDataListener.java
@@ -7,17 +7,17 @@ import com.alibaba.fastjson2.JSON;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Define an AnalysisEventListener to handler the Analysis event
  *
  *
  */
+@Slf4j
 public class SimpleDataListener extends AnalysisEventListener<SimpleData> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(SimpleDataListener.class);
+
     List<SimpleData> list = new ArrayList<SimpleData>();
 
     /**
@@ -28,7 +28,7 @@ public class SimpleDataListener extends AnalysisEventListener<SimpleData> {
      */
     @Override
     public void invokeHeadMap(Map<Integer, String> headMap, AnalysisContext context) {
-        LOGGER.debug("Head is:{}", JSON.toJSONString(headMap));
+        log.debug("Head is:{}", JSON.toJSONString(headMap));
         Assertions.assertEquals(headMap.get(0), "姓名");
     }
 
@@ -66,6 +66,6 @@ public class SimpleDataListener extends AnalysisEventListener<SimpleData> {
                         .getHeadNameList()
                         .get(0),
                 "姓名");
-        LOGGER.debug("First row:{}", JSON.toJSONString(list.get(0)));
+        log.debug("First row:{}", JSON.toJSONString(list.get(0)));
     }
 }

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/core/simple/SimpleDataSheetNameListener.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/core/simple/SimpleDataSheetNameListener.java
@@ -5,15 +5,14 @@ import cn.idev.excel.event.AnalysisEventListener;
 import com.alibaba.fastjson2.JSON;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  *
  */
+@Slf4j
 public class SimpleDataSheetNameListener extends AnalysisEventListener<SimpleData> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(SimpleDataSheetNameListener.class);
     List<SimpleData> list = new ArrayList<SimpleData>();
 
     @Override
@@ -25,6 +24,6 @@ public class SimpleDataSheetNameListener extends AnalysisEventListener<SimpleDat
     public void doAfterAllAnalysed(AnalysisContext context) {
         Assertions.assertEquals(list.size(), 1);
         Assertions.assertEquals(list.get(0).getName(), "张三");
-        LOGGER.debug("First row:{}", JSON.toJSONString(list.get(0)));
+        log.debug("First row:{}", JSON.toJSONString(list.get(0)));
     }
 }

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/core/sort/SortDataListener.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/core/sort/SortDataListener.java
@@ -4,16 +4,15 @@ import cn.idev.excel.context.AnalysisContext;
 import cn.idev.excel.event.AnalysisEventListener;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  *
  */
+@Slf4j
 public class SortDataListener extends AnalysisEventListener<SortData> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(SortDataListener.class);
     List<SortData> list = new ArrayList<SortData>();
 
     @Override

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/core/style/StyleDataListener.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/core/style/StyleDataListener.java
@@ -2,19 +2,17 @@ package cn.idev.excel.test.core.style;
 
 import cn.idev.excel.context.AnalysisContext;
 import cn.idev.excel.event.AnalysisEventListener;
-import cn.idev.excel.test.core.simple.SimpleDataListener;
 import com.alibaba.fastjson2.JSON;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  *
  */
+@Slf4j
 public class StyleDataListener extends AnalysisEventListener<StyleData> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(SimpleDataListener.class);
     List<StyleData> list = new ArrayList<StyleData>();
 
     @Override
@@ -27,6 +25,6 @@ public class StyleDataListener extends AnalysisEventListener<StyleData> {
         Assertions.assertEquals(list.size(), 2);
         Assertions.assertEquals(list.get(0).getString(), "字符串0");
         Assertions.assertEquals(list.get(1).getString(), "字符串1");
-        LOGGER.debug("First row:{}", JSON.toJSONString(list.get(0)));
+        log.debug("First row:{}", JSON.toJSONString(list.get(0)));
     }
 }

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/core/template/TemplateDataListener.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/core/template/TemplateDataListener.java
@@ -2,19 +2,18 @@ package cn.idev.excel.test.core.template;
 
 import cn.idev.excel.context.AnalysisContext;
 import cn.idev.excel.event.AnalysisEventListener;
-import cn.idev.excel.test.core.simple.SimpleDataListener;
 import com.alibaba.fastjson2.JSON;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  *
  */
+@Slf4j
 public class TemplateDataListener extends AnalysisEventListener<TemplateData> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(SimpleDataListener.class);
+
     List<TemplateData> list = new ArrayList<TemplateData>();
 
     @Override
@@ -27,6 +26,6 @@ public class TemplateDataListener extends AnalysisEventListener<TemplateData> {
         Assertions.assertEquals(list.size(), 2);
         Assertions.assertEquals(list.get(0).getString0(), "字符串0");
         Assertions.assertEquals(list.get(1).getString0(), "字符串1");
-        LOGGER.debug("First row:{}", JSON.toJSONString(list.get(0)));
+        log.debug("First row:{}", JSON.toJSONString(list.get(0)));
     }
 }

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/temp/Lock2Test.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/temp/Lock2Test.java
@@ -32,8 +32,6 @@ import org.apache.poi.ss.util.CellReference;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * 临时测试
@@ -43,7 +41,7 @@ import org.slf4j.LoggerFactory;
 @Slf4j
 public class Lock2Test {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(Lock2Test.class);
+
 
     @Test
     public void test() throws Exception {
@@ -52,10 +50,10 @@ public class Lock2Test {
                 .sheet(0)
                 .headRowNumber(0)
                 .doReadSync();
-        LOGGER.info("数据：{}", list.size());
+        log.info("数据：{}", list.size());
         for (Object data : list) {
-            LOGGER.info("返回数据：{}", CollectionUtils.size(data));
-            LOGGER.info("返回数据：{}", JSON.toJSONString(data));
+            log.info("返回数据：{}", CollectionUtils.size(data));
+            log.info("返回数据：{}", JSON.toJSONString(data));
         }
     }
 
@@ -128,7 +126,7 @@ public class Lock2Test {
 
     @Test
     public void testc() throws Exception {
-        LOGGER.info("reslut:{}", JSON.toJSONString(new CellReference("B3")));
+        log.info("reslut:{}", JSON.toJSONString(new CellReference("B3")));
     }
 
     @Test
@@ -147,54 +145,54 @@ public class Lock2Test {
         File file = tempDir.resolve(System.currentTimeMillis() + ".xlsx").toFile();
         EasyExcel.write().file(file).sheet().doWrite(dataList());
         List<Object> list = EasyExcel.read(file).sheet().headRowNumber(0).doReadSync();
-        LOGGER.info("数据：{}", list.size());
+        log.info("数据：{}", list.size());
         for (Object data : list) {
-            LOGGER.info("返回数据：{}", JSON.toJSONString(data));
+            log.info("返回数据：{}", JSON.toJSONString(data));
         }
-        LOGGER.info("文件状态：{}", file.exists());
+        log.info("文件状态：{}", file.exists());
         file.delete();
     }
 
     @Test
     public void test335() throws Exception {
 
-        LOGGER.info("reslut:{}", PositionUtils.getCol("A10", null));
-        LOGGER.info("reslut:{}", PositionUtils.getRow("A10"));
-        LOGGER.info("reslut:{}", PositionUtils.getCol("AB10", null));
-        LOGGER.info("reslut:{}", PositionUtils.getRow("AB10"));
+        log.info("reslut:{}", PositionUtils.getCol("A10", null));
+        log.info("reslut:{}", PositionUtils.getRow("A10"));
+        log.info("reslut:{}", PositionUtils.getCol("AB10", null));
+        log.info("reslut:{}", PositionUtils.getRow("AB10"));
 
-        // LOGGER.info("reslut:{}", PositionUtils2.getCol("A10",null));
-        // LOGGER.info("reslut:{}", PositionUtils2.getRow("A10"));
-        // LOGGER.info("reslut:{}", PositionUtils2.getCol("AB10",null));
-        // LOGGER.info("reslut:{}", PositionUtils2.getRow("AB10"));
+        // log.info("reslut:{}", PositionUtils2.getCol("A10",null));
+        // log.info("reslut:{}", PositionUtils2.getRow("A10"));
+        // log.info("reslut:{}", PositionUtils2.getCol("AB10",null));
+        // log.info("reslut:{}", PositionUtils2.getRow("AB10"));
     }
 
     @Test
     public void numberforamt() throws Exception {
         SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
 
-        // LOGGER.info("date:{}",
+        // log.info("date:{}",
         //    NumberDataFormatterUtils.format(BigDecimal.valueOf(44727.99998842592), (short)200, "yyyy-MM-dd HH:mm:ss",
         //        null,
         //        null, null));
         //
-        // LOGGER.info("date:{}",
+        // log.info("date:{}",
         //    NumberDataFormatterUtils.format(BigDecimal.valueOf(44728.99998842592), (short)200, "yyyy-MM-dd HH:mm:ss",
         //        null,
         //        null, null));
         //
-        // LOGGER.info("date:{}",
+        // log.info("date:{}",
         //    NumberDataFormatterUtils.format(BigDecimal.valueOf(44729.99998836806), (short)200, "yyyy-MM-dd HH:mm:ss",
         //        null,
         //        null, null));
         //
-        // LOGGER.info("date:{}",
+        // log.info("date:{}",
         //    NumberDataFormatterUtils.format(BigDecimal.valueOf(44727.99998842592).setScale(10, RoundingMode
         //    .HALF_UP), (short)200, "yyyy-MM-dd HH:mm:ss",
         //        null,
         //        null, null));
         //
-        // LOGGER.info("date:{}",
+        // log.info("date:{}",
         //    NumberDataFormatterUtils.format(BigDecimal.valueOf(44728.99998842592).setScale(10, RoundingMode
         //    .HALF_UP), (short)200, "yyyy-MM-dd HH:mm:ss",
         //        null,
@@ -202,46 +200,46 @@ public class Lock2Test {
 
         // 44729.9999883681
         // 44729.999988368058
-        // LOGGER.info("date:{}",
+        // log.info("date:{}",
         //    NumberDataFormatterUtils.format(BigDecimal.valueOf(44729.999988368058).setScale(10, RoundingMode
         //    .HALF_UP), (short)200, "yyyy-MM-dd HH:mm:ss",
         //        null,
         //        null, null));
-        // LOGGER.info("date:{}",BigDecimal.valueOf(44729.999988368058).setScale(10, RoundingMode.HALF_UP).doubleValue
+        // log.info("date:{}",BigDecimal.valueOf(44729.999988368058).setScale(10, RoundingMode.HALF_UP).doubleValue
         // ());
 
         // 2022/6/17 23:59:59
         // 期望 44729.99998842592
-        // LOGGER.info("data:{}", DateUtil.getJavaDate(44729.9999883681, true));
-        LOGGER.info(
+        // log.info("data:{}", DateUtil.getJavaDate(44729.9999883681, true));
+        log.info(
                 "data4:{}",
                 DateUtil.getJavaDate(
                         BigDecimal.valueOf(44729.999988368058)
                                 .setScale(4, RoundingMode.HALF_UP)
                                 .doubleValue(),
                         false));
-        LOGGER.info(
+        log.info(
                 "data5:{}",
                 DateUtil.getJavaDate(
                         BigDecimal.valueOf(44729.999988368058)
                                 .setScale(5, RoundingMode.HALF_UP)
                                 .doubleValue(),
                         false));
-        LOGGER.info(
+        log.info(
                 "data6:{}",
                 DateUtil.getJavaDate(
                         BigDecimal.valueOf(44729.999988368058)
                                 .setScale(6, RoundingMode.HALF_UP)
                                 .doubleValue(),
                         false));
-        LOGGER.info(
+        log.info(
                 "data7:{}",
                 DateUtil.getJavaDate(
                         BigDecimal.valueOf(44729.999988368058)
                                 .setScale(7, RoundingMode.HALF_UP)
                                 .doubleValue(),
                         false));
-        LOGGER.info(
+        log.info(
                 "data8:{}",
                 DateUtil.getJavaDate(
                         BigDecimal.valueOf(44729.999988368058)
@@ -249,11 +247,11 @@ public class Lock2Test {
                                 .doubleValue(),
                         false));
 
-        LOGGER.info("data:{}", format.format(DateUtil.getJavaDate(44729.999988368058, false)));
-        LOGGER.info("data:{}", format.format(DateUtil.getJavaDate(44729.9999883681, false)));
+        log.info("data:{}", format.format(DateUtil.getJavaDate(44729.999988368058, false)));
+        log.info("data:{}", format.format(DateUtil.getJavaDate(44729.9999883681, false)));
 
-        LOGGER.info("data:{}", DateUtil.getJavaDate(Double.parseDouble("44729.999988368058"), false));
-        LOGGER.info("data:{}", DateUtil.getJavaDate(Double.parseDouble("44729.9999883681"), false));
+        log.info("data:{}", DateUtil.getJavaDate(Double.parseDouble("44729.999988368058"), false));
+        log.info("data:{}", DateUtil.getJavaDate(Double.parseDouble("44729.9999883681"), false));
 
         // 44729.999976851854
         // 44729.999988368058
@@ -261,14 +259,14 @@ public class Lock2Test {
         // 44729.99998842592
         Assertions.assertThrows(ParseException.class, () -> DateUtil.getExcelDate(format.parse("2022-06-17 23:59:59")));
 
-        LOGGER.info(
+        log.info(
                 "data:{}",
                 DateUtil.getJavaDate(
                         BigDecimal.valueOf(44729.999976851854)
                                 .setScale(10, RoundingMode.HALF_UP)
                                 .doubleValue(),
                         false));
-        LOGGER.info(
+        log.info(
                 "data:{}",
                 DateUtil.getJavaDate(
                         BigDecimal.valueOf(44729.99998842592)
@@ -276,14 +274,14 @@ public class Lock2Test {
                                 .doubleValue(),
                         false));
 
-        LOGGER.info(
+        log.info(
                 "data:{}",
                 DateUtil.getJavaDate(
                         BigDecimal.valueOf(44729.999976851854)
                                 .setScale(5, RoundingMode.HALF_UP)
                                 .doubleValue(),
                         false));
-        LOGGER.info(
+        log.info(
                 "data:{}",
                 DateUtil.getJavaDate(
                         BigDecimal.valueOf(44729.99998842592)
@@ -314,7 +312,7 @@ public class Lock2Test {
             //            Assertions.assertEquals("测试精度5转换错误" + dateTime, format.format(date),
             //                format.format(DateUtil.getJavaDate(BigDecimal.valueOf(excelDate)
             //                    .setScale(10, RoundingMode.HALF_UP).doubleValue(), false)));
-            LOGGER.info(
+            log.info(
                     "date:{}",
                     format2.format(DateUtil.getJavaDate(BigDecimal.valueOf(excelDate)
                             .setScale(10, RoundingMode.HALF_UP)
@@ -341,10 +339,10 @@ public class Lock2Test {
                 .sheet(0)
                 .headRowNumber(0)
                 .doReadSync();
-        LOGGER.info("数据：{}", list.size());
+        log.info("数据：{}", list.size());
         for (Map<Integer, ReadCellData> readCellDataMap : list) {
             ReadCellData data = readCellDataMap.get(0);
-            LOGGER.info(
+            log.info(
                     "data:{}",
                     format.format(DateUtil.getJavaDate(
                             data.getNumberValue()
@@ -353,8 +351,8 @@ public class Lock2Test {
                             false)));
         }
         //
-        // LOGGER.info("data:{}", format.format(DateUtil.getJavaDate(44727.999988425923, false)));
-        // LOGGER.info("data:{}", format.format(DateUtil.getJavaDate(44729.999988368058, false)));
+        // log.info("data:{}", format.format(DateUtil.getJavaDate(44727.999988425923, false)));
+        // log.info("data:{}", format.format(DateUtil.getJavaDate(44729.999988368058, false)));
 
     }
 

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/temp/LockDataListener.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/temp/LockDataListener.java
@@ -2,20 +2,18 @@ package cn.idev.excel.test.temp;
 
 import cn.idev.excel.context.AnalysisContext;
 import cn.idev.excel.event.AnalysisEventListener;
-import cn.idev.excel.test.demo.read.DemoDataListener;
 import com.alibaba.fastjson2.JSON;
 import java.util.ArrayList;
 import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 模板的读取类
  *
  *
  */
+@Slf4j
 public class LockDataListener extends AnalysisEventListener<LockData> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(DemoDataListener.class);
     /**
      * 每隔5条存储数据库，实际使用中可以100条，然后清理list ，方便内存回收
      */
@@ -25,7 +23,7 @@ public class LockDataListener extends AnalysisEventListener<LockData> {
 
     @Override
     public void invoke(LockData data, AnalysisContext context) {
-        LOGGER.info("解析到一条数据:{}", JSON.toJSONString(data));
+        log.info("解析到一条数据:{}", JSON.toJSONString(data));
         list.add(data);
         if (list.size() >= BATCH_COUNT) {
             saveData();
@@ -36,14 +34,14 @@ public class LockDataListener extends AnalysisEventListener<LockData> {
     @Override
     public void doAfterAllAnalysed(AnalysisContext context) {
         saveData();
-        LOGGER.info("所有数据解析完成！");
+        log.info("所有数据解析完成！");
     }
 
     /**
      * 加上存储数据库
      */
     private void saveData() {
-        LOGGER.info("{}条数据，开始存储数据库！", list.size());
-        LOGGER.info("存储数据库成功！");
+        log.info("{}条数据，开始存储数据库！", list.size());
+        log.info("存储数据库成功！");
     }
 }

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/temp/LockTest.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/temp/LockTest.java
@@ -5,17 +5,17 @@ import com.alibaba.fastjson2.JSON;
 import java.io.FileInputStream;
 import java.util.List;
 import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * 临时测试
  *
  *
  **/
+@Slf4j
 public class LockTest {
-    private static final Logger LOGGER = LoggerFactory.getLogger(LockTest.class);
+
 
     @Test
     public void test() throws Exception {
@@ -23,7 +23,7 @@ public class LockTest {
                 .useDefaultListener(false)
                 .doReadAllSync();
         for (Object data : list) {
-            LOGGER.info("返回数据：{}", JSON.toJSONString(data));
+            log.info("返回数据：{}", JSON.toJSONString(data));
         }
     }
 
@@ -34,8 +34,8 @@ public class LockTest {
                 .headRowNumber(0)
                 .doReadSync();
         for (Object data : list) {
-            LOGGER.info("返回数据：{}", ((Map) data).size());
-            LOGGER.info("返回数据：{}", JSON.toJSONString(data));
+            log.info("返回数据：{}", ((Map) data).size());
+            log.info("返回数据：{}", JSON.toJSONString(data));
         }
     }
 }

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/temp/StyleTest.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/temp/StyleTest.java
@@ -5,6 +5,7 @@ import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Date;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.poi.ss.usermodel.BuiltinFormats;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.DateUtil;
@@ -15,17 +16,15 @@ import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.usermodel.WorkbookFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * 临时测试
  *
  *
  **/
+@Slf4j
 public class StyleTest {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(StyleTest.class);
 
     @Test
     public void poi07Test() throws Exception {
@@ -86,18 +85,18 @@ public class StyleTest {
     public void testFormatter2() throws Exception {
         StyleData styleData = new StyleData();
         Field field = styleData.getClass().getDeclaredField("byteValue");
-        LOGGER.info("field:{}", field.getType().getName());
+        log.info("field:{}", field.getType().getName());
         field = styleData.getClass().getDeclaredField("byteValue2");
-        LOGGER.info("field:{}", field.getType().getName());
+        log.info("field:{}", field.getType().getName());
         field = styleData.getClass().getDeclaredField("byteValue4");
-        LOGGER.info("field:{}", field.getType());
+        log.info("field:{}", field.getType());
         field = styleData.getClass().getDeclaredField("byteValue3");
-        LOGGER.info("field:{}", field.getType());
+        log.info("field:{}", field.getType());
     }
 
     @Test
     public void testFormatter3() throws Exception {
-        LOGGER.info("field:{}", Byte.class == Byte.class);
+        log.info("field:{}", Byte.class == Byte.class);
     }
 
     private boolean isDate(Cell cell) {

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/temp/WriteLargeTest.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/temp/WriteLargeTest.java
@@ -31,8 +31,6 @@ import org.apache.poi.poifs.filesystem.POIFSFileSystem;
 import org.apache.poi.ss.usermodel.FillPatternType;
 import org.apache.poi.ss.usermodel.IndexedColors;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  *
@@ -40,7 +38,7 @@ import org.slf4j.LoggerFactory;
 @Slf4j
 public class WriteLargeTest {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(WriteLargeTest.class);
+
 
     @Test
     public void test() throws Exception {
@@ -73,7 +71,7 @@ public class WriteLargeTest {
         WriteSheet writeSheet = EasyExcel.writerSheet().build();
         for (int j = 0; j < 100; j++) {
             excelWriter.write(data(), writeSheet);
-            LOGGER.info("{} fill success.", j);
+            log.info("{} fill success.", j);
         }
         excelWriter.finish();
     }
@@ -172,7 +170,7 @@ public class WriteLargeTest {
         WriteSheet writeSheet = EasyExcel.writerSheet().build();
         for (int j = 0; j < 100; j++) {
             excelWriter.write(data(), writeSheet);
-            LOGGER.info("{} fill success.", j);
+            log.info("{} fill success.", j);
         }
         excelWriter.finish();
     }

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/temp/WriteV33Test.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/temp/WriteV33Test.java
@@ -18,8 +18,6 @@ import org.apache.poi.ss.usermodel.IndexedColors;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * 临时测试
@@ -28,7 +26,6 @@ import org.slf4j.LoggerFactory;
  **/
 public class WriteV33Test {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(WriteV33Test.class);
 
     @Test
     public void handlerStyleWrite() {

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/temp/WriteV34Test.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/temp/WriteV34Test.java
@@ -11,8 +11,6 @@ import java.util.List;
 import org.apache.poi.ss.usermodel.FillPatternType;
 import org.apache.poi.ss.usermodel.IndexedColors;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * 临时测试
@@ -21,7 +19,7 @@ import org.slf4j.LoggerFactory;
  **/
 public class WriteV34Test {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(WriteV34Test.class);
+
 
     @Test
     public void test() throws Exception {

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/temp/Xls03Test.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/temp/Xls03Test.java
@@ -7,18 +7,18 @@ import cn.idev.excel.util.BeanMapUtils;
 import com.alibaba.fastjson2.JSON;
 import java.nio.file.Path;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * 临时测试
  *
  *
  **/
+@Slf4j
 public class Xls03Test {
-    private static final Logger LOGGER = LoggerFactory.getLogger(Xls03Test.class);
+
 
     @TempDir
     Path tempDir;
@@ -29,7 +29,7 @@ public class Xls03Test {
                 .sheet()
                 .doReadSync();
         for (Object data : list) {
-            LOGGER.info("返回数据：{}", JSON.toJSONString(data));
+            log.info("返回数据：{}", JSON.toJSONString(data));
         }
     }
 
@@ -45,9 +45,9 @@ public class Xls03Test {
 
         BeanMap beanMap = BeanMapUtils.create(camlData);
 
-        LOGGER.info("test:{}", beanMap.get("test"));
-        LOGGER.info("test:{}", beanMap.get("Test"));
-        LOGGER.info("test:{}", beanMap.get("TEst"));
-        LOGGER.info("test:{}", beanMap.get("TEST"));
+        log.info("test:{}", beanMap.get("test"));
+        log.info("test:{}", beanMap.get("Test"));
+        log.info("test:{}", beanMap.get("TEst"));
+        log.info("test:{}", beanMap.get("TEST"));
     }
 }

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/temp/cache/CacheTest.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/temp/cache/CacheTest.java
@@ -1,11 +1,11 @@
 package cn.idev.excel.test.temp.cache;
 
-import cn.idev.excel.test.temp.poi.Poi2Test;
 import cn.idev.excel.util.FileUtils;
 import com.alibaba.fastjson2.JSON;
 import java.io.File;
 import java.util.HashMap;
 import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
 import org.ehcache.Cache;
 import org.ehcache.PersistentCacheManager;
 import org.ehcache.config.builders.CacheConfigurationBuilder;
@@ -13,14 +13,12 @@ import org.ehcache.config.builders.CacheManagerBuilder;
 import org.ehcache.config.builders.ResourcePoolsBuilder;
 import org.ehcache.config.units.MemoryUnit;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  *
  **/
+@Slf4j
 public class CacheTest {
-    private static final Logger LOGGER = LoggerFactory.getLogger(Poi2Test.class);
 
     @Test
     public void cache() throws Exception {
@@ -43,10 +41,10 @@ public class CacheTest {
         map.put(1, "test");
 
         cache.put(1, map);
-        LOGGER.info("dd1:{}", JSON.toJSONString(cache.get(1)));
+        log.info("dd1:{}", JSON.toJSONString(cache.get(1)));
 
         cache.clear();
 
-        LOGGER.info("dd2:{}", JSON.toJSONString(cache.get(1)));
+        log.info("dd2:{}", JSON.toJSONString(cache.get(1)));
     }
 }

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/temp/dataformat/DataFormatTest.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/temp/dataformat/DataFormatTest.java
@@ -3,7 +3,6 @@ package cn.idev.excel.test.temp.dataformat;
 import cn.idev.excel.EasyExcel;
 import cn.idev.excel.metadata.data.FormulaData;
 import cn.idev.excel.test.core.dataformat.DateFormatData;
-import cn.idev.excel.test.temp.Lock2Test;
 import cn.idev.excel.test.util.TestFileUtil;
 import com.alibaba.fastjson2.JSON;
 import java.io.File;
@@ -13,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.regex.Pattern;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.DataFormatter;
@@ -20,17 +20,15 @@ import org.apache.poi.ss.usermodel.DateUtil;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * 格式测试
  *
  *
  **/
+@Slf4j
 public class DataFormatTest {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(Lock2Test.class);
 
     @Test
     public void test() throws Exception {
@@ -41,7 +39,7 @@ public class DataFormatTest {
                 .sheet()
                 .headRowNumber(1)
                 .doReadSync();
-        LOGGER.info("数据：{}", list.size());
+        log.info("数据：{}", list.size());
         for (DataFormatData data : list) {
             cn.idev.excel.metadata.data.DataFormatData dataFormat =
                     data.getDate().getDataFormatData();
@@ -51,14 +49,14 @@ public class DataFormatTest {
             if (dataFormat == null || dataFormatString == null) {
 
             } else {
-                LOGGER.info(
+                log.info(
                         "格式化：{};{}：{}",
                         dataFormat.getIndex(),
                         dataFormatString.getFormulaValue(),
                         DateUtil.isADateFormat(dataFormat.getIndex(), dataFormatString.getFormulaValue()));
             }
 
-            LOGGER.info("返回数据：{}", JSON.toJSONString(data));
+            log.info("返回数据：{}", JSON.toJSONString(data));
         }
     }
 
@@ -70,7 +68,7 @@ public class DataFormatTest {
                 .sheet()
                 .headRowNumber(1)
                 .doReadSync();
-        LOGGER.info("数据：{}", list.size());
+        log.info("数据：{}", list.size());
         for (DataFormatData data : list) {
             cn.idev.excel.metadata.data.DataFormatData dataFormat =
                     data.getDate().getDataFormatData();
@@ -80,14 +78,14 @@ public class DataFormatTest {
             if (dataFormat == null || dataFormatString == null) {
 
             } else {
-                LOGGER.info(
+                log.info(
                         "格式化：{};{}：{}",
                         dataFormat.getIndex(),
                         dataFormatString.getFormulaValue(),
                         DateUtil.isADateFormat(dataFormat.getIndex(), dataFormatString.getFormulaValue()));
             }
 
-            LOGGER.info("返回数据：{}", JSON.toJSONString(data));
+            log.info("返回数据：{}", JSON.toJSONString(data));
         }
     }
 
@@ -155,7 +153,7 @@ public class DataFormatTest {
         List<DateFormatData> list =
                 EasyExcel.read(file, DateFormatData.class, null).sheet().doReadSync();
         for (DateFormatData data : list) {
-            LOGGER.info("返回:{}", JSON.toJSONString(data));
+            log.info("返回:{}", JSON.toJSONString(data));
         }
     }
 

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/temp/large/LargeDataListener.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/temp/large/LargeDataListener.java
@@ -3,29 +3,29 @@ package cn.idev.excel.test.temp.large;
 import cn.idev.excel.context.AnalysisContext;
 import cn.idev.excel.event.AnalysisEventListener;
 import com.alibaba.fastjson2.JSON;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  *
  */
+@Slf4j
 public class LargeDataListener extends AnalysisEventListener<LargeData> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(LargeDataListener.class);
+
     private int count = 0;
 
     @Override
     public void invoke(LargeData data, AnalysisContext context) {
         if (count == 0) {
-            LOGGER.info("First row:{}", JSON.toJSONString(data));
+            log.info("First row:{}", JSON.toJSONString(data));
         }
         count++;
         if (count % 100000 == 0) {
-            LOGGER.info("Already read:{}", count);
+            log.info("Already read:{}", count);
         }
     }
 
     @Override
     public void doAfterAllAnalysed(AnalysisContext context) {
-        LOGGER.info("Large row count:{}", count);
+        log.info("Large row count:{}", count);
     }
 }

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/temp/large/NoModelLargeDataListener.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/temp/large/NoModelLargeDataListener.java
@@ -4,30 +4,29 @@ import cn.idev.excel.context.AnalysisContext;
 import cn.idev.excel.event.AnalysisEventListener;
 import com.alibaba.fastjson2.JSON;
 import java.util.Map;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  *
  */
+@Slf4j
 public class NoModelLargeDataListener extends AnalysisEventListener<Map<Integer, String>> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(NoModelLargeDataListener.class);
     private int count = 0;
 
     @Override
     public void invoke(Map<Integer, String> data, AnalysisContext context) {
         if (count == 0) {
-            LOGGER.info("First row:{}", JSON.toJSONString(data));
+            log.info("First row:{}", JSON.toJSONString(data));
         }
         count++;
         if (count % 100000 == 0) {
-            LOGGER.info("Already read:{}", count);
+            log.info("Already read:{}", count);
         }
     }
 
     @Override
     public void doAfterAllAnalysed(AnalysisContext context) {
-        LOGGER.info("Large row count:{}", count);
+        log.info("Large row count:{}", count);
     }
 }

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/temp/large/TempLargeDataTest.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/temp/large/TempLargeDataTest.java
@@ -11,6 +11,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.poi.openxml4j.util.ZipSecureFile;
 import org.apache.poi.xssf.streaming.SXSSFCell;
 import org.apache.poi.xssf.streaming.SXSSFRow;
@@ -19,15 +20,13 @@ import org.apache.poi.xssf.streaming.SXSSFWorkbook;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  *
  */
+@Slf4j
 public class TempLargeDataTest {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(TempLargeDataTest.class);
 
     private int i = 0;
 
@@ -63,7 +62,7 @@ public class TempLargeDataTest {
                 .headRowNumber(2)
                 .sheet()
                 .doRead();
-        LOGGER.info("Large data total time spent:{}", System.currentTimeMillis() - start);
+        log.info("Large data total time spent:{}", System.currentTimeMillis() - start);
     }
 
     @Test
@@ -73,7 +72,7 @@ public class TempLargeDataTest {
         EasyExcel.read("src/test/resources/simple/no_model_10000_rows.xlsx", new NoModelLargeDataListener())
                 .sheet()
                 .doRead();
-        LOGGER.info("Large data total time spent:{}", System.currentTimeMillis() - start);
+        log.info("Large data total time spent:{}", System.currentTimeMillis() - start);
     }
 
     @Test
@@ -92,11 +91,11 @@ public class TempLargeDataTest {
         writeSheet = EasyExcel.writerSheet().build();
         for (int j = 0; j < 5000; j++) {
             excelWriter.write(data(), writeSheet);
-            LOGGER.info("{} write success.", j);
+            log.info("{} write success.", j);
         }
         excelWriter.finish();
         long cost = System.currentTimeMillis() - start;
-        LOGGER.info("write cost:{}", cost);
+        log.info("write cost:{}", cost);
         start = System.currentTimeMillis();
         try (FileOutputStream fileOutputStream = new FileOutputStream(fileWritePoi07)) {
             SXSSFWorkbook workbook = new SXSSFWorkbook();
@@ -108,15 +107,15 @@ public class TempLargeDataTest {
                     cell.setCellValue("str-" + j + "-" + i);
                 }
                 if (i % 5000 == 0) {
-                    LOGGER.info("{} write success.", i);
+                    log.info("{} write success.", i);
                 }
             }
             workbook.write(fileOutputStream);
             workbook.close();
         }
         long costPoi = System.currentTimeMillis() - start;
-        LOGGER.info("poi write cost:{}", System.currentTimeMillis() - start);
-        LOGGER.info("{} vs {}", cost, costPoi);
+        log.info("poi write cost:{}", System.currentTimeMillis() - start);
+        log.info("{} vs {}", cost, costPoi);
         Assertions.assertTrue(costPoi * 2 > cost);
     }
 
@@ -132,7 +131,7 @@ public class TempLargeDataTest {
                 }
                 excelWriter.finish();
             }
-            LOGGER.info("{} 完成", index);
+            log.info("{} 完成", index);
         });
     }
 
@@ -148,7 +147,7 @@ public class TempLargeDataTest {
                 }
                 excelWriter.finish();
             }
-            LOGGER.info("{} 完成", index);
+            log.info("{} 完成", index);
         });
     }
 
@@ -170,15 +169,15 @@ public class TempLargeDataTest {
                         // }
                     }
                     if (i % 5000 == 0) {
-                        LOGGER.info("{} write success.", i);
+                        log.info("{} write success.", i);
                     }
                 }
                 workbook.write(fileOutputStream);
                 workbook.close();
             } catch (Exception e) {
-                LOGGER.error(e.getMessage(), e);
+                log.error(e.getMessage(), e);
             }
-            LOGGER.info("{} 完成", index);
+            log.info("{} 完成", index);
         });
     }
 

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/temp/poi/Poi2Test.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/temp/poi/Poi2Test.java
@@ -1,6 +1,7 @@
 package cn.idev.excel.test.temp.poi;
 
 import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.poi.xssf.streaming.SXSSFRow;
 import org.apache.poi.xssf.streaming.SXSSFSheet;
 import org.apache.poi.xssf.streaming.SXSSFWorkbook;
@@ -8,37 +9,36 @@ import org.apache.poi.xssf.usermodel.XSSFRow;
 import org.apache.poi.xssf.usermodel.XSSFSheet;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * 测试poi
  *
  *
  **/
+@Slf4j
 public class Poi2Test {
-    private static final Logger LOGGER = LoggerFactory.getLogger(Poi2Test.class);
+
 
     @Test
     public void test() throws IOException {
         String file = "src/test/resources/poi/last_row_number_test.xlsx";
         SXSSFWorkbook xssfWorkbook = new SXSSFWorkbook(new XSSFWorkbook(file));
         SXSSFSheet xssfSheet = xssfWorkbook.getSheetAt(0);
-        LOGGER.info("一共行数:{}", xssfSheet.getLastRowNum());
+        log.info("一共行数:{}", xssfSheet.getLastRowNum());
         SXSSFRow row = xssfSheet.getRow(0);
-        LOGGER.info("第一行数据:{}", row);
+        log.info("第一行数据:{}", row);
     }
 
     @Test
     public void lastRowNumXSSF() throws IOException {
         String file = "src/test/resources/poi/last_row_number_xssf_test.xlsx";
         XSSFWorkbook xssfWorkbook = new XSSFWorkbook(file);
-        LOGGER.info("一共:{}个sheet", xssfWorkbook.getNumberOfSheets());
+        log.info("一共:{}个sheet", xssfWorkbook.getNumberOfSheets());
         XSSFSheet xssfSheet = xssfWorkbook.getSheetAt(0);
-        LOGGER.info("一共行数:{}", xssfSheet.getLastRowNum());
+        log.info("一共行数:{}", xssfSheet.getLastRowNum());
         XSSFRow row = xssfSheet.getRow(0);
-        LOGGER.info("第一行数据:{}", row);
+        log.info("第一行数据:{}", row);
         xssfSheet.createRow(20);
-        LOGGER.info("一共行数:{}", xssfSheet.getLastRowNum());
+        log.info("一共行数:{}", xssfSheet.getLastRowNum());
     }
 }

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/temp/poi/Poi3Test.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/temp/poi/Poi3Test.java
@@ -5,6 +5,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.nio.file.Path;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.poi.EncryptedDocumentException;
 import org.apache.poi.hssf.record.crypto.Biff8EncryptionKey;
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
@@ -17,16 +18,15 @@ import org.apache.poi.poifs.filesystem.POIFSFileSystem;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * 测试poi
  *
  *
  **/
+@Slf4j
 public class Poi3Test {
-    private static final Logger LOGGER = LoggerFactory.getLogger(Poi3Test.class);
+
 
     @Test
     public void Encryption(@TempDir Path tempDir) throws Exception {

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/temp/poi/PoiDateFormatTest.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/temp/poi/PoiDateFormatTest.java
@@ -1,34 +1,34 @@
 package cn.idev.excel.test.temp.poi;
 
 import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.poi.ss.usermodel.DateUtil;
 import org.apache.poi.xssf.usermodel.XSSFCell;
 import org.apache.poi.xssf.usermodel.XSSFRow;
 import org.apache.poi.xssf.usermodel.XSSFSheet;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * 测试poi
  *
  *
  **/
+@Slf4j
 public class PoiDateFormatTest {
-    private static final Logger LOGGER = LoggerFactory.getLogger(PoiDateFormatTest.class);
+
 
     @Test
     public void read() throws IOException {
         String file = "src/test/resources/dataformat/dataformat.xlsx";
         XSSFWorkbook xssfWorkbook = new XSSFWorkbook(file);
         XSSFSheet xssfSheet = xssfWorkbook.getSheetAt(0);
-        LOGGER.info("一共行数:{}", xssfSheet.getLastRowNum());
+        log.info("一共行数:{}", xssfSheet.getLastRowNum());
         XSSFRow row = xssfSheet.getRow(7);
         XSSFCell cell = row.getCell(0);
-        LOGGER.info("dd{}", cell.getDateCellValue());
-        LOGGER.info("dd{}", cell.getNumericCellValue());
+        log.info("dd{}", cell.getDateCellValue());
+        log.info("dd{}", cell.getNumericCellValue());
 
-        LOGGER.info("dd{}", DateUtil.isCellDateFormatted(cell));
+        log.info("dd{}", DateUtil.isCellDateFormatted(cell));
     }
 }

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/temp/poi/PoiFormatTest.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/temp/poi/PoiFormatTest.java
@@ -2,6 +2,7 @@ package cn.idev.excel.test.temp.poi;
 
 import java.io.IOException;
 import java.util.Locale;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.poi.ss.usermodel.DataFormatter;
 import org.apache.poi.xssf.streaming.SXSSFRow;
 import org.apache.poi.xssf.streaming.SXSSFSheet;
@@ -11,39 +12,38 @@ import org.apache.poi.xssf.usermodel.XSSFRow;
 import org.apache.poi.xssf.usermodel.XSSFSheet;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * 测试poi
  *
  *
  **/
+@Slf4j
 public class PoiFormatTest {
-    private static final Logger LOGGER = LoggerFactory.getLogger(PoiFormatTest.class);
+
 
     @Test
     public void lastRowNum() throws IOException {
         String file = "src/test/resources/poi/last_row_number_test.xlsx";
         SXSSFWorkbook xssfWorkbook = new SXSSFWorkbook(new XSSFWorkbook(file));
         SXSSFSheet xssfSheet = xssfWorkbook.getSheetAt(0);
-        LOGGER.info("一共行数:{}", xssfSheet.getLastRowNum());
+        log.info("一共行数:{}", xssfSheet.getLastRowNum());
         SXSSFRow row = xssfSheet.getRow(0);
-        LOGGER.info("第一行数据:{}", row);
+        log.info("第一行数据:{}", row);
         xssfSheet.createRow(20);
-        LOGGER.info("一共行数:{}", xssfSheet.getLastRowNum());
+        log.info("一共行数:{}", xssfSheet.getLastRowNum());
     }
 
     @Test
     public void lastRowNumXSSF() throws IOException {
         String file = "src/test/resources/poi/last_row_number_xssf_test.xlsx";
         XSSFWorkbook xssfWorkbook = new XSSFWorkbook(file);
-        LOGGER.info("一共:{}个sheet", xssfWorkbook.getNumberOfSheets());
+        log.info("一共:{}个sheet", xssfWorkbook.getNumberOfSheets());
         XSSFSheet xssfSheet = xssfWorkbook.getSheetAt(0);
-        LOGGER.info("一共行数:{}", xssfSheet.getLastRowNum());
+        log.info("一共行数:{}", xssfSheet.getLastRowNum());
         XSSFRow row = xssfSheet.getRow(1);
         XSSFCell xssfCell = row.getCell(0);
         DataFormatter d = new DataFormatter(Locale.CHINA);
-        LOGGER.info("fo:{}", d.formatCellValue(xssfCell));
+        log.info("fo:{}", d.formatCellValue(xssfCell));
     }
 }

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/temp/poi/PoiTest.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/temp/poi/PoiTest.java
@@ -9,6 +9,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Date;
 import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.poi.hssf.usermodel.HSSFCellStyle;
 import org.apache.poi.hssf.usermodel.HSSFFont;
 import org.apache.poi.hssf.usermodel.HSSFRow;
@@ -31,16 +32,14 @@ import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * 测试poi
  *
  *
  **/
+@Slf4j
 public class PoiTest {
-    private static final Logger LOGGER = LoggerFactory.getLogger(PoiTest.class);
 
     @TempDir
     Path tempDir;
@@ -54,14 +53,14 @@ public class PoiTest {
         try (SXSSFWorkbook xssfWorkbook = new SXSSFWorkbook(new XSSFWorkbook(new File(file))); ) {
             SXSSFSheet xssfSheet = xssfWorkbook.getSheetAt(0);
             Assertions.assertEquals(-1, xssfSheet.getLastRowNum());
-            LOGGER.info("一共行数:{}", xssfSheet.getLastRowNum());
+            log.info("一共行数:{}", xssfSheet.getLastRowNum());
             xssfSheet.createRow(10);
             SXSSFRow row = xssfSheet.getRow(10);
             SXSSFCell cell1 = row.createCell(0);
             SXSSFCell cell2 = row.createCell(1);
             cell1.setCellValue(new Date());
             cell2.setCellValue(new Date());
-            LOGGER.info("dd{}", row.getCell(0).getColumnIndex());
+            log.info("dd{}", row.getCell(0).getColumnIndex());
             Date date = row.getCell(1).getDateCellValue();
         }
     }
@@ -76,31 +75,31 @@ public class PoiTest {
                 FileOutputStream fileOutputStream = new FileOutputStream(
                         tempDir.resolve(System.currentTimeMillis() + ".xlsx").toFile()); ) {
 
-            LOGGER.info("一共:{}个sheet", xssfWorkbook.getNumberOfSheets());
+            log.info("一共:{}个sheet", xssfWorkbook.getNumberOfSheets());
             XSSFSheet xssfSheet = xssfWorkbook.getSheetAt(0);
-            LOGGER.info("一共行数:{}", xssfSheet.getLastRowNum());
+            log.info("一共行数:{}", xssfSheet.getLastRowNum());
             XSSFRow row = xssfSheet.getRow(1);
-            LOGGER.info("dd{}", row.getCell(0).getRow().getRowNum());
-            LOGGER.info("dd{}", xssfSheet.getLastRowNum());
+            log.info("dd{}", row.getCell(0).getRow().getRowNum());
+            log.info("dd{}", xssfSheet.getLastRowNum());
 
             XSSFCellStyle cellStyle = row.getCell(0).getCellStyle();
-            LOGGER.info("size1:{}", cellStyle.getFontIndexAsInt());
+            log.info("size1:{}", cellStyle.getFontIndexAsInt());
 
             XSSFCellStyle cellStyle1 = xssfWorkbook.createCellStyle();
-            LOGGER.info("size2:{}", cellStyle1.getFontIndexAsInt());
+            log.info("size2:{}", cellStyle1.getFontIndexAsInt());
 
             cellStyle1.cloneStyleFrom(cellStyle);
-            LOGGER.info("size3:{}", cellStyle1.getFontIndexAsInt());
+            log.info("size3:{}", cellStyle1.getFontIndexAsInt());
 
-            LOGGER.info("bbb:{}", cellStyle1.getFont().getXSSFColor().getIndex());
-            LOGGER.info("bbb:{}", cellStyle1.getFont().getXSSFColor().getIndexed());
+            log.info("bbb:{}", cellStyle1.getFont().getXSSFColor().getIndex());
+            log.info("bbb:{}", cellStyle1.getFont().getXSSFColor().getIndexed());
             XSSFColor myColor =
                     new XSSFColor(cellStyle1.getFont().getXSSFColor().getRGB(), null);
-            LOGGER.info("bbb:{}", cellStyle1.getFont().getXSSFColor().getRGB());
-            LOGGER.info("bbb:{}", cellStyle1.getFont().getXSSFColor().getARGBHex());
+            log.info("bbb:{}", cellStyle1.getFont().getXSSFColor().getRGB());
+            log.info("bbb:{}", cellStyle1.getFont().getXSSFColor().getARGBHex());
 
-            LOGGER.info("bbb:{}", cellStyle1.getFont().getBold());
-            LOGGER.info("bbb:{}", cellStyle1.getFont().getFontName());
+            log.info("bbb:{}", cellStyle1.getFont().getBold());
+            log.info("bbb:{}", cellStyle1.getFont().getFontName());
 
             XSSFFont xssfFont = xssfWorkbook.createFont();
 
@@ -111,7 +110,7 @@ public class PoiTest {
             cellStyle1.setFont(xssfFont);
             cellStyle1.setFillForegroundColor(IndexedColors.PINK.getIndex());
 
-            LOGGER.info("aaa:{}", cellStyle1.getFont().getColor());
+            log.info("aaa:{}", cellStyle1.getFont().getColor());
 
             row.getCell(1).setCellStyle(cellStyle1);
             row.getCell(1).setCellValue(3334l);
@@ -122,12 +121,12 @@ public class PoiTest {
             // cellStyle2.setFont(cellStyle1.getFont());
             row.getCell(2).setCellStyle(cellStyle2);
             row.getCell(2).setCellValue(3334l);
-            // LOGGER.info("date1:{}",  row.getCell(0).getStringCellValue());
-            // LOGGER.info("date2:{}", ((XSSFColor) cellStyle.getFillForegroundColorColor()).getIndex());
-            // LOGGER.info("date2:{}", ((XSSFColor) cellStyle.getFillForegroundColorColor()).isRGB());
-            // LOGGER.info("date4:{}", ((XSSFColor) cellStyle.getFillForegroundColorColor()).isIndexed());
-            // LOGGER.info("date3:{}", cellStyle.getFont().getXSSFColor().getRGB());
-            // LOGGER.info("date4:{}", cellStyle.getFont().getCTFont().getColorArray(0).getRgb());
+            // log.info("date1:{}",  row.getCell(0).getStringCellValue());
+            // log.info("date2:{}", ((XSSFColor) cellStyle.getFillForegroundColorColor()).getIndex());
+            // log.info("date2:{}", ((XSSFColor) cellStyle.getFillForegroundColorColor()).isRGB());
+            // log.info("date4:{}", ((XSSFColor) cellStyle.getFillForegroundColorColor()).isIndexed());
+            // log.info("date3:{}", cellStyle.getFont().getXSSFColor().getRGB());
+            // log.info("date4:{}", cellStyle.getFont().getCTFont().getColorArray(0).getRgb());
             xssfWorkbook.write(fileOutputStream);
         }
     }
@@ -140,23 +139,23 @@ public class PoiTest {
         Files.copy(Paths.get(sourceFile), Paths.get(file));
         try (HSSFWorkbook xssfWorkbook = new HSSFWorkbook(Files.newInputStream(Paths.get(file.toString())));
                 FileOutputStream fileOutputStream = new FileOutputStream(new File(file))) {
-            LOGGER.info("一共:{}个sheet", xssfWorkbook.getNumberOfSheets());
+            log.info("一共:{}个sheet", xssfWorkbook.getNumberOfSheets());
             HSSFSheet xssfSheet = xssfWorkbook.getSheetAt(0);
-            LOGGER.info("一共行数:{}", xssfSheet.getLastRowNum());
+            log.info("一共行数:{}", xssfSheet.getLastRowNum());
             HSSFRow row = xssfSheet.getRow(1);
-            LOGGER.info("dd{}", row.getCell(0).getRow().getRowNum());
-            LOGGER.info("dd{}", xssfSheet.getLastRowNum());
+            log.info("dd{}", row.getCell(0).getRow().getRowNum());
+            log.info("dd{}", xssfSheet.getLastRowNum());
 
             HSSFCellStyle cellStyle = row.getCell(0).getCellStyle();
-            LOGGER.info("单元格1的字体:{}", cellStyle.getFontIndexAsInt());
+            log.info("单元格1的字体:{}", cellStyle.getFontIndexAsInt());
 
             HSSFCellStyle cellStyle1 = xssfWorkbook.createCellStyle();
-            LOGGER.info("size2:{}", cellStyle1.getFontIndexAsInt());
+            log.info("size2:{}", cellStyle1.getFontIndexAsInt());
 
             cellStyle1.cloneStyleFrom(cellStyle);
-            LOGGER.info("单元格2的字体:{}", cellStyle1.getFontIndexAsInt());
+            log.info("单元格2的字体:{}", cellStyle1.getFontIndexAsInt());
 
-            LOGGER.info("bbb:{}", cellStyle1.getFont(xssfWorkbook).getColor());
+            log.info("bbb:{}", cellStyle1.getFont(xssfWorkbook).getColor());
 
             HSSFFont xssfFont = xssfWorkbook.createFont();
 
@@ -166,7 +165,7 @@ public class PoiTest {
             cellStyle1.setFont(xssfFont);
             cellStyle1.setFillForegroundColor(IndexedColors.PINK.getIndex());
 
-            LOGGER.info("aaa:{}", cellStyle1.getFont(xssfWorkbook).getColor());
+            log.info("aaa:{}", cellStyle1.getFont(xssfWorkbook).getColor());
 
             row.getCell(1).setCellStyle(cellStyle1);
             row.getCell(1).setCellValue(3334l);
@@ -177,12 +176,12 @@ public class PoiTest {
             // cellStyle2.setFont(cellStyle1.getFont());
             row.getCell(2).setCellStyle(cellStyle2);
             row.getCell(2).setCellValue(3334l);
-            // LOGGER.info("date1:{}",  row.getCell(0).getStringCellValue());
-            // LOGGER.info("date2:{}", ((XSSFColor) cellStyle.getFillForegroundColorColor()).getIndex());
-            // LOGGER.info("date2:{}", ((XSSFColor) cellStyle.getFillForegroundColorColor()).isRGB());
-            // LOGGER.info("date4:{}", ((XSSFColor) cellStyle.getFillForegroundColorColor()).isIndexed());
-            // LOGGER.info("date3:{}", cellStyle.getFont().getXSSFColor().getRGB());
-            // LOGGER.info("date4:{}", cellStyle.getFont().getCTFont().getColorArray(0).getRgb());
+            // log.info("date1:{}",  row.getCell(0).getStringCellValue());
+            // log.info("date2:{}", ((XSSFColor) cellStyle.getFillForegroundColorColor()).getIndex());
+            // log.info("date2:{}", ((XSSFColor) cellStyle.getFillForegroundColorColor()).isRGB());
+            // log.info("date4:{}", ((XSSFColor) cellStyle.getFillForegroundColorColor()).isIndexed());
+            // log.info("date3:{}", cellStyle.getFont().getXSSFColor().getRGB());
+            // log.info("date4:{}", cellStyle.getFont().getCTFont().getColorArray(0).getRgb());
             xssfWorkbook.write(fileOutputStream);
         }
     }
@@ -226,11 +225,11 @@ public class PoiTest {
         Files.copy(Paths.get(sourceFile), Paths.get(file));
         SXSSFWorkbook xssfWorkbook = new SXSSFWorkbook(new XSSFWorkbook(file));
         SXSSFSheet xssfSheet = xssfWorkbook.getSheetAt(0);
-        LOGGER.info("一共行数:{}", xssfSheet.getLastRowNum());
+        log.info("一共行数:{}", xssfSheet.getLastRowNum());
         SXSSFRow row = xssfSheet.getRow(0);
-        LOGGER.info("第一行数据:{}", row);
+        log.info("第一行数据:{}", row);
         xssfSheet.createRow(20);
-        LOGGER.info("一共行数:{}", xssfSheet.getLastRowNum());
+        log.info("一共行数:{}", xssfSheet.getLastRowNum());
     }
 
     @Test
@@ -323,9 +322,9 @@ public class PoiTest {
         Files.copy(Paths.get(sourceFile), Paths.get(file));
         SXSSFWorkbook xssfWorkbook = new SXSSFWorkbook(new XSSFWorkbook(file));
         Sheet xssfSheet = xssfWorkbook.getXSSFWorkbook().getSheetAt(0);
-        LOGGER.info("一共行数:{}", xssfSheet.getPhysicalNumberOfRows());
-        LOGGER.info("一共行数:{}", xssfSheet.getLastRowNum());
-        LOGGER.info("一共行数:{}", xssfSheet.getFirstRowNum());
+        log.info("一共行数:{}", xssfSheet.getPhysicalNumberOfRows());
+        log.info("一共行数:{}", xssfSheet.getLastRowNum());
+        log.info("一共行数:{}", xssfSheet.getFirstRowNum());
     }
 
     @Test
@@ -334,10 +333,10 @@ public class PoiTest {
         String file = tempDir.resolve(System.currentTimeMillis() + ".xlsx").toString();
         Files.copy(Paths.get(sourceFile), Paths.get(file));
         XSSFWorkbook xssfWorkbook = new XSSFWorkbook(file);
-        LOGGER.info("一共:{}个sheet", xssfWorkbook.getNumberOfSheets());
+        log.info("一共:{}个sheet", xssfWorkbook.getNumberOfSheets());
         XSSFSheet xssfSheet = xssfWorkbook.getSheetAt(0);
-        LOGGER.info("一共行数:{}", xssfSheet.getLastRowNum());
+        log.info("一共行数:{}", xssfSheet.getLastRowNum());
         XSSFRow row = xssfSheet.getRow(0);
-        LOGGER.info("第一行数据:{}", row);
+        log.info("第一行数据:{}", row);
     }
 }

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/temp/poi/PoiWriteTest.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/temp/poi/PoiWriteTest.java
@@ -11,8 +11,6 @@ import org.apache.poi.xssf.streaming.SXSSFSheet;
 import org.apache.poi.xssf.streaming.SXSSFWorkbook;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * 测试poi
@@ -21,7 +19,7 @@ import org.slf4j.LoggerFactory;
  **/
 public class PoiWriteTest {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(PoiWriteTest.class);
+
 
     @Test
     public void write0(@TempDir Path path) throws IOException {

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/temp/read/CommentTest.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/temp/read/CommentTest.java
@@ -10,14 +10,13 @@ import com.alibaba.fastjson2.JSON;
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@Slf4j
 public class CommentTest {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(CommentTest.class);
 
     private final List<String> commentList = Arrays.asList("测试", "comment");
 
@@ -36,7 +35,7 @@ public class CommentTest {
 
                     @Override
                     public void extra(CellExtra extra, AnalysisContext context) {
-                        LOGGER.info("读取到了一条额外信息:{}", JSON.toJSONString(extra));
+                        log.info("读取到了一条额外信息:{}", JSON.toJSONString(extra));
                         if (extra.getType().equals(CellExtraTypeEnum.COMMENT)) {
                             Assertions.assertTrue(commentList.contains(extra.getText()));
                         }

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/temp/read/HDListener.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/temp/read/HDListener.java
@@ -4,16 +4,16 @@ import cn.idev.excel.context.AnalysisContext;
 import cn.idev.excel.event.AnalysisEventListener;
 import com.alibaba.fastjson2.JSON;
 import java.util.Map;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 模板的读取类
  *
  *
  */
+@Slf4j
 public class HDListener extends AnalysisEventListener<HeadReadData> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(HDListener.class);
+
     /**
      * 每隔5条存储数据库，实际使用中可以100条，然后清理list ，方便内存回收
      */
@@ -21,18 +21,18 @@ public class HDListener extends AnalysisEventListener<HeadReadData> {
 
     @Override
     public void invokeHeadMap(Map<Integer, String> headMap, AnalysisContext context) {
-        LOGGER.info("HEAD:{}", JSON.toJSONString(headMap));
-        LOGGER.info("total:{}", context.readSheetHolder().getTotal());
+        log.info("HEAD:{}", JSON.toJSONString(headMap));
+        log.info("total:{}", context.readSheetHolder().getTotal());
     }
 
     @Override
     public void invoke(HeadReadData data, AnalysisContext context) {
-        LOGGER.info("index:{}", context.readRowHolder().getRowIndex());
-        LOGGER.info("解析到一条数据:{}", JSON.toJSONString(data));
+        log.info("index:{}", context.readRowHolder().getRowIndex());
+        log.info("解析到一条数据:{}", JSON.toJSONString(data));
     }
 
     @Override
     public void doAfterAllAnalysed(AnalysisContext context) {
-        LOGGER.info("所有数据解析完成！");
+        log.info("所有数据解析完成！");
     }
 }

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/temp/read/HeadListener.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/temp/read/HeadListener.java
@@ -4,16 +4,16 @@ import cn.idev.excel.context.AnalysisContext;
 import cn.idev.excel.event.AnalysisEventListener;
 import com.alibaba.fastjson2.JSON;
 import java.util.Map;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 模板的读取类
  *
  *
  */
+@Slf4j
 public class HeadListener extends AnalysisEventListener<HeadReadData> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(HeadListener.class);
+
     /**
      * 每隔5条存储数据库，实际使用中可以100条，然后清理list ，方便内存回收
      */
@@ -21,18 +21,18 @@ public class HeadListener extends AnalysisEventListener<HeadReadData> {
 
     @Override
     public void invokeHeadMap(Map<Integer, String> headMap, AnalysisContext context) {
-        LOGGER.info("HEAD:{}", JSON.toJSONString(headMap));
-        LOGGER.info("total:{}", context.readSheetHolder().getTotal());
+        log.info("HEAD:{}", JSON.toJSONString(headMap));
+        log.info("total:{}", context.readSheetHolder().getTotal());
     }
 
     @Override
     public void invoke(HeadReadData data, AnalysisContext context) {
-        LOGGER.info("index:{}", context.readRowHolder().getRowIndex());
-        LOGGER.info("解析到一条数据:{}", JSON.toJSONString(data));
+        log.info("index:{}", context.readRowHolder().getRowIndex());
+        log.info("解析到一条数据:{}", JSON.toJSONString(data));
     }
 
     @Override
     public void doAfterAllAnalysed(AnalysisContext context) {
-        LOGGER.info("所有数据解析完成！");
+        log.info("所有数据解析完成！");
     }
 }

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/temp/read/HeadReadTest.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/temp/read/HeadReadTest.java
@@ -3,17 +3,17 @@ package cn.idev.excel.test.temp.read;
 import cn.idev.excel.EasyExcel;
 import cn.idev.excel.cache.Ehcache;
 import java.io.File;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * 临时测试
  *
  *
  **/
+@Slf4j
 public class HeadReadTest {
-    private static final Logger LOGGER = LoggerFactory.getLogger(HeadReadTest.class);
+
 
     @Test
     public void test() throws Exception {
@@ -32,12 +32,12 @@ public class HeadReadTest {
                 .sheet(0)
                 .doRead();
 
-        LOGGER.info("------------------");
+        log.info("------------------");
         EasyExcel.read(file, HeadReadData.class, new HDListener())
                 .readCache(new Ehcache(20))
                 .sheet(0)
                 .doRead();
-        LOGGER.info("------------------");
+        log.info("------------------");
         EasyExcel.read(file, HeadReadData.class, new HDListener())
                 .readCache(new Ehcache(20))
                 .sheet(0)

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/temp/simple/HgListener.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/temp/simple/HgListener.java
@@ -4,16 +4,16 @@ import cn.idev.excel.context.AnalysisContext;
 import cn.idev.excel.event.AnalysisEventListener;
 import com.alibaba.fastjson2.JSON;
 import java.util.Map;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 模板的读取类
  *
  *
  */
+@Slf4j
 public class HgListener extends AnalysisEventListener<Map<Integer, String>> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(HgListener.class);
+
     /**
      * 每隔5条存储数据库，实际使用中可以100条，然后清理list ，方便内存回收
      */
@@ -21,12 +21,12 @@ public class HgListener extends AnalysisEventListener<Map<Integer, String>> {
 
     @Override
     public void invoke(Map<Integer, String> data, AnalysisContext context) {
-        LOGGER.info("index:{}", context.readRowHolder().getRowIndex());
-        LOGGER.info("解析到一条数据:{}", JSON.toJSONString(data));
+        log.info("index:{}", context.readRowHolder().getRowIndex());
+        log.info("解析到一条数据:{}", JSON.toJSONString(data));
     }
 
     @Override
     public void doAfterAllAnalysed(AnalysisContext context) {
-        LOGGER.info("所有数据解析完成！");
+        log.info("所有数据解析完成！");
     }
 }

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/temp/simple/RepeatListener.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/temp/simple/RepeatListener.java
@@ -2,21 +2,20 @@ package cn.idev.excel.test.temp.simple;
 
 import cn.idev.excel.context.AnalysisContext;
 import cn.idev.excel.event.AnalysisEventListener;
-import cn.idev.excel.test.demo.read.DemoDataListener;
 import cn.idev.excel.test.temp.LockData;
 import com.alibaba.fastjson2.JSON;
 import java.util.ArrayList;
 import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 模板的读取类
  *
  *
  */
+@Slf4j
 public class RepeatListener extends AnalysisEventListener<LockData> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(DemoDataListener.class);
+
     /**
      * 每隔5条存储数据库，实际使用中可以100条，然后清理list ，方便内存回收
      */
@@ -26,7 +25,7 @@ public class RepeatListener extends AnalysisEventListener<LockData> {
 
     @Override
     public void invoke(LockData data, AnalysisContext context) {
-        LOGGER.info("解析到一条数据:{}", JSON.toJSONString(data));
+        log.info("解析到一条数据:{}", JSON.toJSONString(data));
         list.add(data);
         if (list.size() >= BATCH_COUNT) {
             saveData();
@@ -37,14 +36,14 @@ public class RepeatListener extends AnalysisEventListener<LockData> {
     @Override
     public void doAfterAllAnalysed(AnalysisContext context) {
         saveData();
-        LOGGER.info("所有数据解析完成！");
+        log.info("所有数据解析完成！");
     }
 
     /**
      * 加上存储数据库
      */
     private void saveData() {
-        LOGGER.info("{}条数据，开始存储数据库！", list.size());
-        LOGGER.info("存储数据库成功！");
+        log.info("{}条数据，开始存储数据库！", list.size());
+        log.info("存储数据库成功！");
     }
 }

--- a/fastexcel-test/src/test/java/cn/idev/excel/test/temp/simple/Write.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/temp/simple/Write.java
@@ -15,8 +15,6 @@ import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * 测试poi
@@ -25,7 +23,6 @@ import org.slf4j.LoggerFactory;
  **/
 @Slf4j
 public class Write {
-    private static final Logger LOGGER = LoggerFactory.getLogger(Write.class);
 
     @Test
     public void simpleWrite1() {

--- a/fastexcel/src/main/java/cn/idev/excel/analysis/ExcelAnalyserImpl.java
+++ b/fastexcel/src/main/java/cn/idev/excel/analysis/ExcelAnalyserImpl.java
@@ -26,14 +26,13 @@ import cn.idev.excel.util.NumberDataFormatterUtils;
 import cn.idev.excel.util.StringUtils;
 import java.io.InputStream;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.poi.hssf.record.crypto.Biff8EncryptionKey;
 import org.apache.poi.poifs.crypt.Decryptor;
 import org.apache.poi.poifs.filesystem.DocumentFactoryHelper;
 import org.apache.poi.poifs.filesystem.POIFSFileSystem;
 import org.apache.poi.util.IOUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A class that implements the ExcelAnalyser interface for analyzing Excel files.
@@ -49,8 +48,9 @@ import org.slf4j.LoggerFactory;
  * </ul>
  *
  */
+@Slf4j
 public class ExcelAnalyserImpl implements ExcelAnalyser {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ExcelAnalyserImpl.class);
+
 
     /**
      * The context object holding metadata and configuration for the Excel analysis process.
@@ -163,8 +163,8 @@ public class ExcelAnalyserImpl implements ExcelAnalyser {
             try {
                 excelReadExecutor.execute();
             } catch (ExcelAnalysisStopException e) {
-                if (LOGGER.isDebugEnabled()) {
-                    LOGGER.debug("Custom stop!");
+                if (log.isDebugEnabled()) {
+                    log.debug("Custom stop!");
                 }
             }
         } catch (RuntimeException e) {

--- a/fastexcel/src/main/java/cn/idev/excel/analysis/v03/XlsSaxAnalyser.java
+++ b/fastexcel/src/main/java/cn/idev/excel/analysis/v03/XlsSaxAnalyser.java
@@ -59,8 +59,6 @@ import org.apache.poi.hssf.record.Record;
 import org.apache.poi.hssf.record.SSTRecord;
 import org.apache.poi.hssf.record.StringRecord;
 import org.apache.poi.hssf.record.TextObjectRecord;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A text extractor for Excel files.
@@ -78,7 +76,7 @@ import org.slf4j.LoggerFactory;
 @Slf4j
 public class XlsSaxAnalyser implements HSSFListener, ExcelReadExecutor {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(XlsSaxAnalyser.class);
+
     private static final short DUMMY_RECORD_SID = -1;
     private final XlsReadContext xlsReadContext;
     private static final Map<Short, XlsRecordHandler> XLS_RECORD_HANDLER_MAP = new HashMap<Short, XlsRecordHandler>(32);
@@ -130,8 +128,8 @@ public class XlsSaxAnalyser implements HSSFListener, ExcelReadExecutor {
                 new XlsListSheetListener(xlsReadContext).execute();
             }
         } catch (ExcelAnalysisStopException e) {
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Custom stop!");
+            if (log.isDebugEnabled()) {
+                log.debug("Custom stop!");
             }
         }
         List<ReadSheet> actualSheetDataList =

--- a/fastexcel/src/main/java/cn/idev/excel/analysis/v03/handlers/StringRecordHandler.java
+++ b/fastexcel/src/main/java/cn/idev/excel/analysis/v03/handlers/StringRecordHandler.java
@@ -4,16 +4,15 @@ import cn.idev.excel.analysis.v03.IgnorableXlsRecordHandler;
 import cn.idev.excel.context.xls.XlsReadContext;
 import cn.idev.excel.metadata.data.CellData;
 import cn.idev.excel.read.metadata.holder.xls.XlsReadSheetHolder;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.poi.hssf.record.Record;
 import org.apache.poi.hssf.record.StringRecord;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Record handler
  */
+@Slf4j
 public class StringRecordHandler extends AbstractXlsRecordHandler implements IgnorableXlsRecordHandler {
-    private static final Logger LOGGER = LoggerFactory.getLogger(StringRecordHandler.class);
 
     @Override
     public void processRecord(XlsReadContext xlsReadContext, Record record) {
@@ -22,7 +21,7 @@ public class StringRecordHandler extends AbstractXlsRecordHandler implements Ign
         XlsReadSheetHolder xlsReadSheetHolder = xlsReadContext.xlsReadSheetHolder();
         CellData<?> tempCellData = xlsReadSheetHolder.getTempCellData();
         if (tempCellData == null) {
-            LOGGER.warn("String type formula but no value found.");
+            log.warn("String type formula but no value found.");
             return;
         }
         tempCellData.setStringValue(srec.getString());

--- a/fastexcel/src/main/java/cn/idev/excel/analysis/v03/handlers/TextObjectRecordHandler.java
+++ b/fastexcel/src/main/java/cn/idev/excel/analysis/v03/handlers/TextObjectRecordHandler.java
@@ -4,18 +4,17 @@ import cn.idev.excel.analysis.v03.IgnorableXlsRecordHandler;
 import cn.idev.excel.context.xls.XlsReadContext;
 import cn.idev.excel.enums.CellExtraTypeEnum;
 import cn.idev.excel.read.metadata.holder.xls.XlsReadSheetHolder;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.poi.hssf.record.Record;
 import org.apache.poi.hssf.record.TextObjectRecord;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Record handler
  *
  *
  */
+@Slf4j
 public class TextObjectRecordHandler extends AbstractXlsRecordHandler implements IgnorableXlsRecordHandler {
-    private static final Logger LOGGER = LoggerFactory.getLogger(TextObjectRecordHandler.class);
 
     @Override
     public boolean support(XlsReadContext xlsReadContext, Record record) {
@@ -28,7 +27,7 @@ public class TextObjectRecordHandler extends AbstractXlsRecordHandler implements
         XlsReadSheetHolder xlsReadSheetHolder = xlsReadContext.xlsReadSheetHolder();
         Integer tempObjectIndex = xlsReadSheetHolder.getTempObjectIndex();
         if (tempObjectIndex == null) {
-            LOGGER.debug("tempObjectIndex is null.");
+            log.debug("tempObjectIndex is null.");
             return;
         }
         xlsReadSheetHolder.getObjectCacheMap().put(tempObjectIndex, tor.getStr().getString());

--- a/fastexcel/src/main/java/cn/idev/excel/cache/selector/SimpleReadCacheSelector.java
+++ b/fastexcel/src/main/java/cn/idev/excel/cache/selector/SimpleReadCacheSelector.java
@@ -7,9 +7,8 @@ import java.io.IOException;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.poi.openxml4j.opc.PackagePart;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Simple cache selector
@@ -19,8 +18,9 @@ import org.slf4j.LoggerFactory;
 @Getter
 @Setter
 @EqualsAndHashCode
+@Slf4j
 public class SimpleReadCacheSelector implements ReadCacheSelector {
-    private static final Logger LOGGER = LoggerFactory.getLogger(SimpleReadCacheSelector.class);
+
     /**
      * Convert bytes to megabytes
      */
@@ -76,7 +76,7 @@ public class SimpleReadCacheSelector implements ReadCacheSelector {
             try {
                 size = sharedStringsTablePackagePart.getInputStream().available();
             } catch (IOException e) {
-                LOGGER.warn("Unable to get file size, default used MapCache");
+                log.warn("Unable to get file size, default used MapCache");
                 return new MapCache();
             }
         }
@@ -84,13 +84,13 @@ public class SimpleReadCacheSelector implements ReadCacheSelector {
             maxUseMapCacheSize = DEFAULT_MAX_USE_MAP_CACHE_SIZE;
         }
         if (size < maxUseMapCacheSize * B2M) {
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Use map cache.size:{}", size);
+            if (log.isDebugEnabled()) {
+                log.debug("Use map cache.size:{}", size);
             }
             return new MapCache();
         }
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Use ehcache.size:{}", size);
+        if (log.isDebugEnabled()) {
+            log.debug("Use ehcache.size:{}", size);
         }
 
         // In order to be compatible with the code

--- a/fastexcel/src/main/java/cn/idev/excel/context/WriteContextImpl.java
+++ b/fastexcel/src/main/java/cn/idev/excel/context/WriteContextImpl.java
@@ -32,6 +32,7 @@ import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.util.Map;
 import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.poi.hssf.record.crypto.Biff8EncryptionKey;
 import org.apache.poi.openxml4j.opc.OPCPackage;
 import org.apache.poi.openxml4j.opc.PackageAccess;
@@ -45,8 +46,6 @@ import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.util.CellRangeAddress;
 import org.apache.poi.xssf.streaming.SXSSFWorkbook;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Implementation of the WriteContext interface, which serves as the main anchorage point for writing Excel files.
@@ -54,9 +53,9 @@ import org.slf4j.LoggerFactory;
  * and finishing the write process.
  *
  */
+@Slf4j
 public class WriteContextImpl implements WriteContext {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(WriteContextImpl.class);
     private static final String NO_SHEETS = "no sheets";
 
     /**
@@ -93,8 +92,8 @@ public class WriteContextImpl implements WriteContext {
         if (writeWorkbook == null) {
             throw new IllegalArgumentException("Workbook argument cannot be null");
         }
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Begin to Initialization 'WriteContextImpl'");
+        if (log.isDebugEnabled()) {
+            log.debug("Begin to Initialization 'WriteContextImpl'");
         }
         initCurrentWorkbookHolder(writeWorkbook);
 
@@ -107,8 +106,8 @@ public class WriteContextImpl implements WriteContext {
             throw new ExcelGenerateException("Create workbook failure", e);
         }
         WriteHandlerUtils.afterWorkbookCreate(workbookWriteHandlerContext);
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Initialization 'WriteContextImpl' complete");
+        if (log.isDebugEnabled()) {
+            log.debug("Initialization 'WriteContextImpl' complete");
         }
     }
 
@@ -120,8 +119,8 @@ public class WriteContextImpl implements WriteContext {
     private void initCurrentWorkbookHolder(WriteWorkbook writeWorkbook) {
         writeWorkbookHolder = new WriteWorkbookHolder(writeWorkbook);
         currentWriteHolder = writeWorkbookHolder;
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("CurrentConfiguration is writeWorkbookHolder");
+        if (log.isDebugEnabled()) {
+            log.debug("CurrentConfiguration is writeWorkbookHolder");
         }
     }
 
@@ -175,14 +174,14 @@ public class WriteContextImpl implements WriteContext {
         if (writeSheetHolder == null) {
             return false;
         }
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Sheet:{},{} is already existed", writeSheet.getSheetNo(), writeSheet.getSheetName());
+        if (log.isDebugEnabled()) {
+            log.debug("Sheet:{},{} is already existed", writeSheet.getSheetNo(), writeSheet.getSheetName());
         }
         writeSheetHolder.setNewInitialization(Boolean.FALSE);
         writeTableHolder = null;
         currentWriteHolder = writeSheetHolder;
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("CurrentConfiguration is writeSheetHolder");
+        if (log.isDebugEnabled()) {
+            log.debug("CurrentConfiguration is writeSheetHolder");
         }
         return true;
     }
@@ -196,8 +195,8 @@ public class WriteContextImpl implements WriteContext {
         writeSheetHolder = new WriteSheetHolder(writeSheet, writeWorkbookHolder);
         writeTableHolder = null;
         currentWriteHolder = writeSheetHolder;
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("CurrentConfiguration is writeSheetHolder");
+        if (log.isDebugEnabled()) {
+            log.debug("CurrentConfiguration is writeSheetHolder");
         }
     }
 
@@ -249,8 +248,8 @@ public class WriteContextImpl implements WriteContext {
      * @return The newly created sheet.
      */
     private Sheet createSheet() {
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Can not find sheet:{} ,now create it", writeSheetHolder.getSheetNo());
+        if (log.isDebugEnabled()) {
+            log.debug("Can not find sheet:{} ,now create it", writeSheetHolder.getSheetNo());
         }
         if (StringUtils.isEmpty(writeSheetHolder.getSheetName())) {
             writeSheetHolder.setSheetName(writeSheetHolder.getSheetNo().toString());
@@ -363,14 +362,14 @@ public class WriteContextImpl implements WriteContext {
             writeTable.setTableNo(0);
         }
         if (writeSheetHolder.getHasBeenInitializedTable().containsKey(writeTable.getTableNo())) {
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Table:{} is already existed", writeTable.getTableNo());
+            if (log.isDebugEnabled()) {
+                log.debug("Table:{} is already existed", writeTable.getTableNo());
             }
             writeTableHolder = writeSheetHolder.getHasBeenInitializedTable().get(writeTable.getTableNo());
             writeTableHolder.setNewInitialization(Boolean.FALSE);
             currentWriteHolder = writeTableHolder;
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("CurrentConfiguration is writeTableHolder");
+            if (log.isDebugEnabled()) {
+                log.debug("CurrentConfiguration is writeTableHolder");
             }
             return;
         }
@@ -399,8 +398,8 @@ public class WriteContextImpl implements WriteContext {
         writeTableHolder = new WriteTableHolder(writeTable, writeSheetHolder);
         writeSheetHolder.getHasBeenInitializedTable().put(writeTable.getTableNo(), writeTableHolder);
         currentWriteHolder = writeTableHolder;
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("CurrentConfiguration is writeTableHolder");
+        if (log.isDebugEnabled()) {
+            log.debug("CurrentConfiguration is writeTableHolder");
         }
     }
 
@@ -518,8 +517,8 @@ public class WriteContextImpl implements WriteContext {
         if (throwable != null) {
             throw new ExcelGenerateException("Can not close IO.", throwable);
         }
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Finished write.");
+        if (log.isDebugEnabled()) {
+            log.debug("Finished write.");
         }
     }
 

--- a/fastexcel/src/main/java/cn/idev/excel/metadata/format/DataFormatter.java
+++ b/fastexcel/src/main/java/cn/idev/excel/metadata/format/DataFormatter.java
@@ -34,12 +34,11 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.poi.ss.format.CellFormat;
 import org.apache.poi.ss.format.CellFormatResult;
 import org.apache.poi.ss.usermodel.ExcelStyleDateFormatter;
 import org.apache.poi.ss.usermodel.FractionFormat;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Written with reference to {@link org.apache.poi.ss.usermodel.DataFormatter}.Made some optimizations for date
@@ -49,11 +48,12 @@ import org.slf4j.LoggerFactory;
  *
  *
  */
+@Slf4j
 public class DataFormatter {
     /**
      * For logging any problems we find
      */
-    private static final Logger LOGGER = LoggerFactory.getLogger(DataFormatter.class);
+
 
     private static final String defaultFractionWholePartFormat = "#";
     private static final String defaultFractionFractionPartFormat = "#/##";
@@ -222,7 +222,7 @@ public class DataFormatter {
                 // Wrap and return (non-cachable - CellFormat does that)
                 return new CellFormatResultWrapper(cfmt.apply(cellValueO));
             } catch (Exception e) {
-                LOGGER.warn("Formatting failed for format {}, falling back", formatStr, e);
+                log.warn("Formatting failed for format {}, falling back", formatStr, e);
             }
         }
 
@@ -461,7 +461,7 @@ public class DataFormatter {
         try {
             return new ExcelStyleDateFormatter(formatStr, dateSymbols);
         } catch (IllegalArgumentException iae) {
-            LOGGER.debug("Formatting failed for format {}, falling back", formatStr, iae);
+            log.debug("Formatting failed for format {}, falling back", formatStr, iae);
             // the pattern could not be parsed correctly,
             // so fall back to the default number format
             return getDefaultFormat();
@@ -595,7 +595,7 @@ public class DataFormatter {
         try {
             return new InternalDecimalFormatWithScale(format, symbols);
         } catch (IllegalArgumentException iae) {
-            LOGGER.error("Formatting failed for format {}, falling back", formatStr, iae);
+            log.error("Formatting failed for format {}, falling back", formatStr, iae);
             // the pattern could not be parsed correctly,
             // so fall back to the default number format
             return getDefaultFormat();

--- a/fastexcel/src/main/java/cn/idev/excel/metadata/property/ExcelHeadProperty.java
+++ b/fastexcel/src/main/java/cn/idev/excel/metadata/property/ExcelHeadProperty.java
@@ -16,8 +16,7 @@ import java.util.TreeMap;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Define the header attribute of excel
@@ -26,9 +25,9 @@ import org.slf4j.LoggerFactory;
 @Getter
 @Setter
 @EqualsAndHashCode
+@Slf4j
 public class ExcelHeadProperty {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ExcelHeadProperty.class);
     /**
      * Custom class
      */
@@ -68,8 +67,8 @@ public class ExcelHeadProperty {
         initColumnProperties(configurationHolder);
 
         initHeadRowNumber();
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("The initialization sheet/table 'ExcelHeadProperty' is complete , head kind is {}", headKind);
+        if (log.isDebugEnabled()) {
+            log.debug("The initialization sheet/table 'ExcelHeadProperty' is complete , head kind is {}", headKind);
         }
     }
 

--- a/fastexcel/src/main/java/cn/idev/excel/read/processor/DefaultAnalysisEventProcessor.java
+++ b/fastexcel/src/main/java/cn/idev/excel/read/processor/DefaultAnalysisEventProcessor.java
@@ -18,16 +18,16 @@ import cn.idev.excel.util.StringUtils;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.MapUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Analysis event
  *
  */
+@Slf4j
 public class DefaultAnalysisEventProcessor implements AnalysisEventProcessor {
-    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultAnalysisEventProcessor.class);
+
 
     @Override
     public void extra(AnalysisContext analysisContext) {
@@ -47,8 +47,8 @@ public class DefaultAnalysisEventProcessor implements AnalysisEventProcessor {
         // Check if the current row is empty
         if (RowTypeEnum.EMPTY.equals(analysisContext.readRowHolder().getRowType())) {
             // Log debug information if the current row is empty
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Empty row!");
+            if (log.isDebugEnabled()) {
+                log.debug("Empty row!");
             }
             // If the workbook holder is set to ignore empty rows, then directly return
             if (analysisContext.readWorkbookHolder().getIgnoreEmptyRow()) {

--- a/fastexcel/src/main/java/cn/idev/excel/util/SheetUtils.java
+++ b/fastexcel/src/main/java/cn/idev/excel/util/SheetUtils.java
@@ -3,16 +3,15 @@ package cn.idev.excel.util;
 import cn.idev.excel.context.AnalysisContext;
 import cn.idev.excel.read.metadata.ReadSheet;
 import cn.idev.excel.read.metadata.holder.ReadWorkbookHolder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Sheet utils
  *
  *
  */
+@Slf4j
 public class SheetUtils {
-    private static final Logger LOGGER = LoggerFactory.getLogger(SheetUtils.class);
 
     private SheetUtils() {}
 
@@ -37,8 +36,8 @@ public class SheetUtils {
                 continue;
             }
             if (parameterReadSheet.getSheetNo() == null && parameterReadSheet.getSheetName() == null) {
-                if (LOGGER.isDebugEnabled()) {
-                    LOGGER.debug("The first is read by default.");
+                if (log.isDebugEnabled()) {
+                    log.debug("The first is read by default.");
                 }
                 parameterReadSheet.setSheetNo(0);
             }


### PR DESCRIPTION
<!--
Thanks very much for contributing to FastExcel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

Closed: #ISSUE
Related: #ISSUE

-->

## Purpose of the pull request
https://github.com/fast-excel/fastexcel/issues/447
<!-- Describe the purpose of this pull request. For example: Closed: #ISSUE-->

## What's changed?
In our project, we are currently using both `@Slf4j` and `Logger` approaches to print logs. Perhaps we can optimize this by standardizing on the `@Slf4j` annotation from Lombok for all logging operations.


<!--- Describe the change below, including rationale and design decisions -->

## Checklist

- [ ] I have written the necessary doc or comment.
- [ ] I have added the necessary unit tests and all cases have passed.