### PR TITLE
fix: fix hex impacting on xls and csv

### DIFF
--- a/fastexcel-test/src/test/java/cn/idev/excel/test/demo/write/EscapeHexCellWriteHandlerTest.java
+++ b/fastexcel-test/src/test/java/cn/idev/excel/test/demo/write/EscapeHexCellWriteHandlerTest.java
@@ -1,0 +1,284 @@
+package cn.idev.excel.test.demo.write;
+
+import cn.idev.excel.FastExcel;
+import cn.idev.excel.support.ExcelTypeEnum;
+import cn.idev.excel.write.handler.EscapeHexCellWriteHandler;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class EscapeHexCellWriteHandlerTest {
+
+    @TempDir
+    Path tempDir;
+
+    private DemoData createDemoData(String str) {
+        DemoData data = new DemoData();
+        data.setString(str);
+        data.setDate(new Date());
+        data.setDoubleData(123.45);
+        data.setIgnore("ignoreMe");
+        return data;
+    }
+
+    @Test
+    public void testEscapeHex_xlsx_singleHex() throws Exception {
+        List<DemoData> list = new ArrayList<>();
+        list.add(createDemoData("_xB9f0_"));
+
+        File file = tempDir.resolve("testEscapeHex.xlsx").toFile();
+        FastExcel.write(file, DemoData.class)
+                .registerWriteHandler(new EscapeHexCellWriteHandler())
+                .sheet("TestSheet")
+                .doWrite(list);
+
+        // Verify the result
+        try (Workbook workbook = org.apache.poi.ss.usermodel.WorkbookFactory.create(file)) {
+            Sheet sheet = workbook.getSheetAt(0);
+            Row row = sheet.getRow(1); // Data row (header is row 0)
+            Cell cell = row.getCell(0); // String column
+            String actualValue = cell.getStringCellValue();
+            System.out.println("XLSX result: " + actualValue);
+            Assertions.assertNotEquals("_x005F_xB9f0_", actualValue, "xlsx should not escape _xB9f0_ to _x005F_xB9f0_");
+        }
+    }
+
+    @Test
+    public void testEscapeHex_xls_singleHex() throws Exception {
+        List<DemoData> list = new ArrayList<>();
+        list.add(createDemoData("_xB9f0_"));
+
+        File file = tempDir.resolve("testEscapeHex.xls").toFile();
+        FastExcel.write(file, DemoData.class)
+                .excelType(ExcelTypeEnum.XLS)
+                .registerWriteHandler(new EscapeHexCellWriteHandler())
+                .sheet("TestSheet")
+                .doWrite(list);
+
+        // Verify the result
+        try (Workbook workbook = org.apache.poi.ss.usermodel.WorkbookFactory.create(file)) {
+            Sheet sheet = workbook.getSheetAt(0);
+            Row row = sheet.getRow(1);
+            Cell cell = row.getCell(0);
+            Assertions.assertNotEquals(
+                    "_x005F_xB9f0_", cell.getStringCellValue(), "xls should not escape _xB9f0_ to _x005F_xB9f0_");
+        }
+    }
+
+    @Test
+    public void testEscapeHex_csv_singleHex() throws Exception {
+        List<DemoData> list = new ArrayList<>();
+        list.add(createDemoData("_xB9f0_"));
+
+        File file = tempDir.resolve("testEscapeHex.csv").toFile();
+        FastExcel.write(file, DemoData.class)
+                .excelType(ExcelTypeEnum.CSV)
+                .registerWriteHandler(new EscapeHexCellWriteHandler())
+                .sheet("TestSheet")
+                .doWrite(list);
+
+        // Verify the result
+        try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
+            reader.readLine(); // Skip header
+            String dataLine = reader.readLine();
+            Assertions.assertNotNull(dataLine);
+            Assertions.assertFalse(
+                    dataLine.contains("_x005F_xB9f0_"),
+                    "csv should not contain escaped _x005F_xB9f0_, but was: " + dataLine);
+        }
+    }
+
+    @Test
+    public void testEscapeHex_multipleHexInOneString() throws Exception {
+        List<DemoData> list = new ArrayList<>();
+        list.add(createDemoData("_xB9f0_ and _x1234_ and _xABCD_"));
+
+        File file = tempDir.resolve("testMultipleHex.xlsx").toFile();
+        FastExcel.write(file, DemoData.class)
+                .registerWriteHandler(new EscapeHexCellWriteHandler())
+                .sheet("TestSheet")
+                .doWrite(list);
+
+        try (Workbook workbook = org.apache.poi.ss.usermodel.WorkbookFactory.create(file)) {
+            Sheet sheet = workbook.getSheetAt(0);
+            Row row = sheet.getRow(1);
+            Cell cell = row.getCell(0);
+            String expected = "_xB9f0_ and _x1234_ and _xABCD_";
+            Assertions.assertEquals(expected, cell.getStringCellValue(), "Multiple hex patterns should all be escaped");
+        }
+    }
+
+    @Test
+    public void testEscapeHex_noHexPattern() throws Exception {
+        List<DemoData> list = new ArrayList<>();
+        list.add(createDemoData("normalString"));
+
+        File file = tempDir.resolve("testNoHex.xlsx").toFile();
+        FastExcel.write(file, DemoData.class)
+                .registerWriteHandler(new EscapeHexCellWriteHandler())
+                .sheet("TestSheet")
+                .doWrite(list);
+
+        try (Workbook workbook = org.apache.poi.ss.usermodel.WorkbookFactory.create(file)) {
+            Sheet sheet = workbook.getSheetAt(0);
+            Row row = sheet.getRow(1);
+            Cell cell = row.getCell(0);
+            Assertions.assertEquals("normalString", cell.getStringCellValue(), "Normal strings should not be modified");
+        }
+    }
+
+    @Test
+    public void testEscapeHex_partialHexPattern() throws Exception {
+        List<DemoData> list = new ArrayList<>();
+        list.add(createDemoData("_x123_ _xABC_ _x12345_")); // Invalid patterns
+
+        File file = tempDir.resolve("testPartialHex.xlsx").toFile();
+        FastExcel.write(file, DemoData.class)
+                .registerWriteHandler(new EscapeHexCellWriteHandler())
+                .sheet("TestSheet")
+                .doWrite(list);
+
+        try (Workbook workbook = org.apache.poi.ss.usermodel.WorkbookFactory.create(file)) {
+            Sheet sheet = workbook.getSheetAt(0);
+            Row row = sheet.getRow(1);
+            Cell cell = row.getCell(0);
+            Assertions.assertEquals(
+                    "_x123_ _xABC_ _x12345_", cell.getStringCellValue(), "Invalid hex patterns should not be modified");
+        }
+    }
+
+    @Test
+    public void testEscapeHex_mixedValidAndInvalidPatterns() throws Exception {
+        List<DemoData> list = new ArrayList<>();
+        list.add(createDemoData("_x1234_ _x123_ _xABCD_ _xGHIJ_"));
+
+        File file = tempDir.resolve("testMixedHex.xlsx").toFile();
+        FastExcel.write(file, DemoData.class)
+                .registerWriteHandler(new EscapeHexCellWriteHandler())
+                .sheet("TestSheet")
+                .doWrite(list);
+
+        try (Workbook workbook = org.apache.poi.ss.usermodel.WorkbookFactory.create(file)) {
+            Sheet sheet = workbook.getSheetAt(0);
+            Row row = sheet.getRow(1);
+            Cell cell = row.getCell(0);
+            String expected = "_x1234_ _x123_ _xABCD_ _xGHIJ_";
+            Assertions.assertEquals(expected, cell.getStringCellValue(), "Only valid hex patterns should be escaped");
+        }
+    }
+
+    @Test
+    public void testEscapeHex_emptyAndNullStrings() throws Exception {
+        List<DemoData> list = new ArrayList<>();
+        DemoData data1 = createDemoData("");
+        DemoData data2 = createDemoData(null);
+        list.add(data1);
+        list.add(data2);
+
+        File file = tempDir.resolve("testEmptyNull.xlsx").toFile();
+        FastExcel.write(file, DemoData.class)
+                .registerWriteHandler(new EscapeHexCellWriteHandler())
+                .sheet("TestSheet")
+                .doWrite(list);
+
+        try (Workbook workbook = org.apache.poi.ss.usermodel.WorkbookFactory.create(file)) {
+            Sheet sheet = workbook.getSheetAt(0);
+
+            // Check empty string
+            Row row1 = sheet.getRow(1);
+            Cell cell1 = row1.getCell(0);
+            Assertions.assertEquals("", cell1.getStringCellValue(), "Empty string should remain empty");
+
+            // Check null string
+            Row row2 = sheet.getRow(2);
+            Cell cell2 = row2.getCell(0);
+            if (cell2 != null) {
+                Assertions.assertEquals("", cell2.getStringCellValue(), "Null string should be handled gracefully");
+            }
+        }
+    }
+
+    @Test
+    public void testEscapeHex_caseInsensitiveHex() throws Exception {
+        List<DemoData> list = new ArrayList<>();
+        list.add(createDemoData("_x1a2B_ _XC3d4_ _x9F8e_"));
+
+        File file = tempDir.resolve("testCaseInsensitive.xlsx").toFile();
+        FastExcel.write(file, DemoData.class)
+                .registerWriteHandler(new EscapeHexCellWriteHandler())
+                .sheet("TestSheet")
+                .doWrite(list);
+
+        try (Workbook workbook = org.apache.poi.ss.usermodel.WorkbookFactory.create(file)) {
+            Sheet sheet = workbook.getSheetAt(0);
+            Row row = sheet.getRow(1);
+            Cell cell = row.getCell(0);
+            String expected = "_x1a2B_ _XC3d4_ _x9F8e_";
+            Assertions.assertEquals(
+                    expected, cell.getStringCellValue(), "Case-sensitive hex patterns should be handled correctly");
+        }
+    }
+
+    @Test
+    public void testEscapeHex_multipleDifferentFormats() throws Exception {
+        List<DemoData> list = new ArrayList<>();
+        list.add(createDemoData("_xB9f0_"));
+
+        // Test xlsx
+        File xlsxFile = tempDir.resolve("testFormats.xlsx").toFile();
+        FastExcel.write(xlsxFile, DemoData.class)
+                .registerWriteHandler(new EscapeHexCellWriteHandler())
+                .sheet("TestSheet")
+                .doWrite(list);
+
+        // Test xls
+        File xlsFile = tempDir.resolve("testFormats.xls").toFile();
+        FastExcel.write(xlsFile, DemoData.class)
+                .excelType(ExcelTypeEnum.XLS)
+                .registerWriteHandler(new EscapeHexCellWriteHandler())
+                .sheet("TestSheet")
+                .doWrite(list);
+
+        // Test csv
+        File csvFile = tempDir.resolve("testFormats.csv").toFile();
+        FastExcel.write(csvFile, DemoData.class)
+                .excelType(ExcelTypeEnum.CSV)
+                .registerWriteHandler(new EscapeHexCellWriteHandler())
+                .sheet("TestSheet")
+                .doWrite(list);
+
+        // Verify all formats produce the same escaped result
+        try (Workbook xlsxWorkbook = org.apache.poi.ss.usermodel.WorkbookFactory.create(xlsxFile);
+                Workbook xlsWorkbook = org.apache.poi.ss.usermodel.WorkbookFactory.create(xlsFile);
+                BufferedReader csvReader = new BufferedReader(new FileReader(csvFile))) {
+
+            // Check xlsx
+            String xlsxValue = xlsxWorkbook.getSheetAt(0).getRow(1).getCell(0).getStringCellValue();
+            Assertions.assertEquals("_xB9f0_", xlsxValue);
+
+            // Check xls
+            String xlsValue = xlsWorkbook.getSheetAt(0).getRow(1).getCell(0).getStringCellValue();
+            Assertions.assertEquals("_xB9f0_", xlsValue);
+
+            // Check csv
+            csvReader.readLine(); // Skip header
+            String csvLine = csvReader.readLine();
+            Assertions.assertTrue(csvLine.contains("_xB9f0_"));
+            Assertions.assertFalse(csvLine.contains("_x005F_xB9f0_"));
+
+            // All formats should produce the same result
+            Assertions.assertEquals(xlsxValue, xlsValue, "xlsx, csv and xls should produce the same escaped result");
+        }
+    }
+}

--- a/fastexcel/src/main/java/cn/idev/excel/write/handler/EscapeHexCellWriteHandler.java
+++ b/fastexcel/src/main/java/cn/idev/excel/write/handler/EscapeHexCellWriteHandler.java
@@ -5,10 +5,8 @@ import cn.idev.excel.metadata.Head;
 import cn.idev.excel.metadata.data.WriteCellData;
 import cn.idev.excel.write.metadata.holder.WriteSheetHolder;
 import cn.idev.excel.write.metadata.holder.WriteTableHolder;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.xssf.streaming.SXSSFCell;
 
 /**
  * A cell write handler that escapes _x[0-9A-Fa-f]{4}_ format strings to prevent POI from automatically decoding them.
@@ -21,8 +19,6 @@ import org.apache.poi.ss.usermodel.Cell;
  */
 public class EscapeHexCellWriteHandler implements CellWriteHandler {
 
-    private static final Pattern HEX_PATTERN = Pattern.compile("_x([0-9A-Fa-f]{4})_");
-
     @Override
     public void afterCellDataConverted(
             WriteSheetHolder writeSheetHolder,
@@ -32,47 +28,116 @@ public class EscapeHexCellWriteHandler implements CellWriteHandler {
             Head head,
             Integer relativeRowIndex,
             Boolean isHead) {
-        // Only process cell data of string type
-        if (cellData != null && cellData.getType() == CellDataTypeEnum.STRING) {
+        // Only process SXSSFCell (cell in xlsx) and cell data of string type
+        if (cellData != null && cell instanceof SXSSFCell && CellDataTypeEnum.STRING.equals(cellData.getType())) {
             String originalString = cellData.getStringValue();
-            if (originalString != null && HEX_PATTERN.matcher(originalString).find()) {
+            if (originalString != null) {
                 String escapedString = escapeHex(originalString);
                 cellData.setStringValue(escapedString);
             }
         }
     }
 
-    /**
-     * Escapes hexadecimal-encoded strings
-     * Replaces _xHHHH_ with _x005F_xHHHH_ to prevent POI from decoding them
-     */
-    private String escapeHex(String originalString) {
-        Matcher matcher = HEX_PATTERN.matcher(originalString);
-        StringBuffer sb = new StringBuffer();
-        while (matcher.find()) {
-            // Replace _xHHHH_ with _x005F_xHHHH_
-            matcher.appendReplacement(sb, "_x005F_x" + matcher.group(1) + "_");
-        }
-        matcher.appendTail(sb);
-        return sb.toString();
+    // Static hex lookup table for O(1) character validation
+    private static final boolean[] HEX_TABLE = new boolean[128];
+
+    static {
+        for (char c = '0'; c <= '9'; c++) HEX_TABLE[c] = true;
+        for (char c = 'A'; c <= 'F'; c++) HEX_TABLE[c] = true;
+        for (char c = 'a'; c <= 'f'; c++) HEX_TABLE[c] = true;
     }
 
-    @Override
-    public void afterCellCreate(
-            WriteSheetHolder writeSheetHolder,
-            WriteTableHolder writeTableHolder,
-            Cell cell,
-            Head head,
-            Integer relativeRowIndex,
-            Boolean isHead) {}
+    /**
+     * Escapes hexadecimal-encoded strings with optimized performance Replaces _xHHHH_ with _x005F_xHHHH_ to prevent POI
+     * from decoding them
+     */
+    private String escapeHex(String originalString) {
+        int length = originalString.length();
 
-    @Override
-    public void afterCellDispose(
-            WriteSheetHolder writeSheetHolder,
-            WriteTableHolder writeTableHolder,
-            List<WriteCellData<?>> cellDataList,
-            Cell cell,
-            Head head,
-            Integer relativeRowIndex,
-            Boolean isHead) {}
+        // Fast path: if string is too short to contain pattern, return original
+        if (length < 7) {
+            return originalString;
+        }
+
+        // Fast path: search for first potential pattern
+        int searchStart = 0;
+        int patternIndex;
+        while ((patternIndex = originalString.indexOf("_x", searchStart)) != -1) {
+            // Check if we have enough characters for full pattern
+            if (patternIndex + 6 >= length) {
+                break;
+            }
+
+            // Quick validation: check if it ends with '_' and has valid hex
+            if (originalString.charAt(patternIndex + 6) == '_' && isValidHexFast(originalString, patternIndex + 2)) {
+
+                // Found at least one pattern, proceed with full processing
+                return processWithPatterns(originalString, patternIndex);
+            }
+
+            searchStart = patternIndex + 2;
+        }
+
+        // No valid patterns found
+        return originalString;
+    }
+
+    /**
+     * Process string when we know it contains at least one valid pattern
+     */
+    private String processWithPatterns(String originalString, int firstPatternIndex) {
+        int length = originalString.length();
+        StringBuilder result = new StringBuilder(length + 64); // More generous pre-allocation
+        int lastEnd;
+
+        // Process the first known pattern
+        result.append(originalString, 0, firstPatternIndex);
+        result.append("_x005F_x");
+        result.append(originalString, firstPatternIndex + 2, firstPatternIndex + 6);
+        result.append('_');
+        lastEnd = firstPatternIndex + 7;
+
+        // Continue searching for more patterns
+        int searchStart = firstPatternIndex + 7;
+        int patternIndex;
+        while ((patternIndex = originalString.indexOf("_x", searchStart)) != -1) {
+            if (patternIndex + 6 >= length) {
+                break;
+            }
+
+            if (originalString.charAt(patternIndex + 6) == '_' && isValidHexFast(originalString, patternIndex + 2)) {
+
+                // Append content between patterns
+                result.append(originalString, lastEnd, patternIndex);
+                // Append escaped pattern
+                result.append("_x005F_x");
+                result.append(originalString, patternIndex + 2, patternIndex + 6);
+                result.append('_');
+                lastEnd = patternIndex + 7;
+                searchStart = patternIndex + 7;
+            } else {
+                searchStart = patternIndex + 2;
+            }
+        }
+
+        // Append remaining content
+        if (lastEnd < length) {
+            result.append(originalString, lastEnd, length);
+        }
+
+        return result.toString();
+    }
+
+    /**
+     * Fast hex validation using lookup table - O(1) per character
+     */
+    private static boolean isValidHexFast(String str, int startIndex) {
+        for (int i = 0; i < 4; i++) {
+            char c = str.charAt(startIndex + i);
+            if (c >= 128 || !HEX_TABLE[c]) {
+                return false;
+            }
+        }
+        return true;
+    }
 }


### PR DESCRIPTION
<!--
Thanks very much for contributing to FastExcel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

Closed: #ISSUE
Related: #ISSUE

-->

## Purpose of the pull request

1. add SXSSFCell checking, skip other types
2. recreate escapeHex method for performance tuning
<img width="536" height="69" alt="image" src="https://github.com/user-attachments/assets/852831d3-519d-404d-819b-89c10249d86a" />
<img width="607" height="73" alt="image" src="https://github.com/user-attachments/assets/09cf0ebd-3803-4b65-bd92-b7c91891cdc3" />
<img width="541" height="71" alt="image" src="https://github.com/user-attachments/assets/ed99499a-5d60-4b9b-aeb4-be5d444d848f" />
<img width="531" height="71" alt="image" src="https://github.com/user-attachments/assets/f1d1156f-ebef-40ba-a417-ce9a36110b3f" />
<img width="349" height="211" alt="image" src="https://github.com/user-attachments/assets/f315fbe7-419d-4c29-8419-d45b1c1d3db6" />

3. create relative unit test
<img width="911" height="458" alt="image" src="https://github.com/user-attachments/assets/9f6d3728-e33b-43d3-8e45-003998b6072e" />

Related:  #364

## What's changed?

fastexcel/src/main/java/cn/idev/excel/write/handler/EscapeHexCellWriteHandler.java
fastexcel-test/src/test/java/cn/idev/excel/test/demo/write/EscapeHexCellWriteHandlerTest.java

## Checklist

- [X] I have written the necessary doc or comment.
- [X] I have added the necessary unit tests and all cases have passed.