### PR TITLE
ci: replace npm ci with npm install

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-      - run: cd website && npm ci
+      - run: cd website && npm install
       - run: cd website && npm run build
       - uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
## Purpose of the pull request

repair document workflow

## What's changed?

- replace `npm ci` with `npm install`
