### PR TITLE
doc: add markdownlint-cli2 library

### DIFF
--- a/website/.markdownlint-cli2.jsonc
+++ b/website/.markdownlint-cli2.jsonc
@@ -1,0 +1,32 @@
+{
+  "globs": ["website/**/*.md"],
+  "config": {
+    "default": true,
+    "MD001": true,
+    "MD003": true,
+    "MD013": {
+        "line_length": 600,
+        "code_blocks": false,
+        "tables": false
+    },
+    "MD024": {
+        "siblings_only": true
+    },
+    "MD025": false,
+    "MD029": true,
+    "MD033": {
+      "allowed_elements": ["table", "tr", "td", "a", "img", "sub", "b", "br", "img", "tbody", "mark", "font"]
+    },
+    "MD036": false,
+    "MD040": true,
+    "MD045": true,
+    "MD046": true,
+    "MD047": true,
+    "MD052": true
+  },
+  "ignores": [
+    "**/node_modules/**",
+    "**/target/**",
+    "**/dist/**"
+  ]
+}

--- a/website/community/contribution.md
+++ b/website/community/contribution.md
@@ -141,19 +141,35 @@ Documentation is an important component of the FastExcel official website and se
 ### Documentation Writing Guidelines
 
 - Use file paths with the `.md` extension
-``` markdown
-[Example](quickstart/example.md)
+```markdown
+[Example](docs/quickstart/example.md)
 ```
 
 - Use paths relative to the docs/ directory
-``` markdown
-[Example](quickstart/example.md)
+```markdown
+[Example](docs/quickstart/example.md)
 ```
 
-- Image files must be stored in the `docs/images` directory and referenced using relative directory paths.
-``` markdown
+- Image files must be stored in the `static/img` directory and referenced using relative directory paths.
+```markdown
 [img](/img/docs/fill/listFill_file.png)
 ```
+
+### Document Format Inspection
+
+FastExcel uses [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2) to check document formatting. After writing the relevant Markdown articles, you can run the following command locally to pre-check whether the Markdown formatting meets the requirements:
+
+```bash
+cd website && yarn
+
+yarn md-lint
+
+# If the documentation is wrong, you can use the following command to attempt an automatic repair.
+yarn md-lint-fix
+```
+
+For formatting rules for MD articles you can refer to: [Markdown-lint-rules](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md)
+MD format configuration file in the project: [.markdownlint-cli2.jsonc](https://github.com/fast-excel/fastexcel/blob/main/website/.markdownlint-cli2.jsonc)
 
 ---
 

--- a/website/i18n/zh-cn/docusaurus-plugin-content-docs-community/current/contribution.md
+++ b/website/i18n/zh-cn/docusaurus-plugin-content-docs-community/current/contribution.md
@@ -140,18 +140,36 @@ git config --get user.email
 
 - 使用带有 `.md` 扩展名的文件路径
 ``` markdown
-[Example](quickstart/example.md)
+[Example](docs/quickstart/example.md)
 ```
 
 - 使用相对于 docs/ 目录的路径
 ``` markdown
-[Example](quickstart/example.md)
+[Example](docs/quickstart/example.md)
 ```
 
-- 图片文件需要存储在 `docs/images` 目录，并使用相对目录的形式引用.
+- 图片文件需要存储在 `static/img` 目录，并使用相对目录的形式引用.
 ``` markdown
-[img](../../images/fill/listFill_file.png)
+[img](/img/docs/fill/listFill_file.png)
 ```
+
+### 文档格式校验
+
+FastExcel 使用 [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2) 来检查文档格式。您在编写了相关 Markdown 文章后，可以在本地执行以下命令，来预先检查 Markdown 的格式内容是否符合要求:
+
+```shell
+cd website && yarn
+
+yarn md-lint
+
+# 如果文档错误，可以使用以下命令来尝试自动修复
+yarn md-lint-fix
+```
+
+Markdown 文章的相关格式规则可以参考 [Markdown-lint-rules](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md)
+
+项目中的 Markdown 格式配置文件位于: [.markdownlint-cli2.jsonc](https://github.com/fast-excel/fastexcel/blob/main/website/.markdownlint-cli2.jsonc)
+
 
 ---
 

--- a/website/package.json
+++ b/website/package.json
@@ -5,13 +5,17 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
+    "start-en": "docusaurus start --locale en",
+    "start-zh-cn": "docusaurus start --locale zh-cn",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
-    "write-heading-ids": "docusaurus write-heading-ids"
+    "write-heading-ids": "docusaurus write-heading-ids",
+    "md-lint": "markdownlint-cli2 --config ./.markdownlint-cli2.jsonc \"./**/*.md\" \"#node_modules\"",
+    "md-lint-fix": "yarn md-lint --fix"
   },
   "dependencies": {
     "@docusaurus/core": "3.8.1",
@@ -19,6 +23,7 @@
     "@docusaurus/theme-mermaid": "^3.8.1",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
+    "markdownlint-cli2": "^0.18.1",
     "prism-react-renderer": "^2.3.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"


### PR DESCRIPTION
## Purpose of the pull request

Introduce the [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2) library to validate the format of makdown articles.

## What's changed?

- add markdownlint-cli2 library
- add Markdown format configuration file
- add markdown format inspection guidelines

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide.
- [x] I have written the necessary doc or comment.
