### PR TITLE
feat: add fuzz testing for Excel reading and improve error handling in XlsxSaxAnalyser and CSvReadExecutor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ website/versioned_sidebars
 website/versions.json
 website/pnpm-lock.yaml
 website/yarn.lock
+**/.cifuzz-corpus/
+**/fuzz_corpus/
+**/resources/**/fuzz/*Inputs/

--- a/fastexcel/pom.xml
+++ b/fastexcel/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -131,6 +131,11 @@
                     <groupId>com.fasterxml.jackson.core</groupId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.code-intelligence</groupId>
+            <artifactId>jazzer-junit</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/fastexcel/src/test/java/cn/idev/excel/csv/CsvBenignErrorToleranceTest.java
+++ b/fastexcel/src/test/java/cn/idev/excel/csv/CsvBenignErrorToleranceTest.java
@@ -1,0 +1,84 @@
+package cn.idev.excel.csv;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import cn.idev.excel.FastExcelFactory;
+import cn.idev.excel.exception.ExcelCommonException;
+import cn.idev.excel.read.builder.CsvReaderBuilder;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that truncated/unfinished quoted fields in CSV are treated as benign and
+ * end the current sheet gracefully without throwing to the caller.
+ */
+class CsvBenignErrorToleranceTest {
+
+    @Test
+    void shouldNotThrowOnUnclosedQuotedField_EOFBenign() {
+        // Given: a CSV with an unclosed quoted field that triggers Commons CSV EOF inside quotes
+        String csv = "col1,col2\n\"unfinished,2"; // second line has an unclosed quoted field
+        ByteArrayInputStream in = new ByteArrayInputStream(csv.getBytes(StandardCharsets.UTF_8));
+
+        // When / Then: reading should complete without throwing any exception
+        assertDoesNotThrow(() -> {
+            CsvReaderBuilder builder = FastExcelFactory.read(in).csv();
+            // Use sync read to drive the pipeline end-to-end
+            List<Object> rows = builder.doReadSync();
+            // No strict assertion on content; important is no exception is thrown
+            // and the reader finishes gracefully.
+        });
+    }
+
+    @Test
+    void shouldRethrowOnNonBenignUncheckedIOException() {
+        // Given: a CSV stream that throws a non-benign IOException during read
+        String csv = "a,b\n1,2\n3,4\n";
+        byte[] data = csv.getBytes(StandardCharsets.UTF_8);
+        InputStream throwing = new InputStream() {
+            int idx = 0;
+
+            @Override
+            public int read() throws IOException {
+                if (idx >= data.length) {
+                    return -1;
+                }
+                // After consuming some bytes, simulate an IO failure with a non-benign message
+                if (idx > data.length / 2) {
+                    throw new IOException("Simulated IO failure");
+                }
+                return data[idx++];
+            }
+
+            @Override
+            public int read(byte[] b, int off, int len) throws IOException {
+                // Fallback to single-byte reads to trigger our error logic reliably
+                int i = read();
+                if (i == -1) {
+                    return -1;
+                }
+                b[off] = (byte) i;
+                return 1;
+            }
+        };
+
+        // When / Then: the pipeline should convert UncheckedIOException into ExcelAnalysisException
+        assertThrows(ExcelCommonException.class, () -> {
+            FastExcelFactory.read(throwing).csv().doReadSync();
+        });
+    }
+
+    @Test
+    void shouldReadWellFormedCsvNormally() {
+        String csv = "a,b\n1,2\n3,4\n";
+        ByteArrayInputStream in = new ByteArrayInputStream(csv.getBytes(StandardCharsets.UTF_8));
+        assertDoesNotThrow(() -> {
+            CsvReaderBuilder builder = FastExcelFactory.read(in).csv();
+            List<Object> rows = builder.doReadSync();
+        });
+    }
+}

--- a/fastexcel/src/test/java/cn/idev/excel/exception/XlsxSaxAnalyserReadOpcPackageTest.java
+++ b/fastexcel/src/test/java/cn/idev/excel/exception/XlsxSaxAnalyserReadOpcPackageTest.java
@@ -1,11 +1,10 @@
-package cn.idev.excel.test.core.exception;
+package cn.idev.excel.exception;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import cn.idev.excel.analysis.v07.XlsxSaxAnalyser;
 import cn.idev.excel.context.xlsx.DefaultXlsxReadContext;
 import cn.idev.excel.context.xlsx.XlsxReadContext;
-import cn.idev.excel.exception.ExcelCommonException;
 import cn.idev.excel.read.metadata.ReadWorkbook;
 import cn.idev.excel.support.ExcelTypeEnum;
 import java.io.ByteArrayInputStream;

--- a/fastexcel/src/test/java/cn/idev/excel/exception/XlsxSaxAnalyserReadOpcPackageTest.java
+++ b/fastexcel/src/test/java/cn/idev/excel/exception/XlsxSaxAnalyserReadOpcPackageTest.java
@@ -1,0 +1,99 @@
+package cn.idev.excel.test.core.exception;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import cn.idev.excel.analysis.v07.XlsxSaxAnalyser;
+import cn.idev.excel.context.xlsx.DefaultXlsxReadContext;
+import cn.idev.excel.context.xlsx.XlsxReadContext;
+import cn.idev.excel.exception.ExcelCommonException;
+import cn.idev.excel.read.metadata.ReadWorkbook;
+import cn.idev.excel.support.ExcelTypeEnum;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.zip.ZipOutputStream;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for XlsxSaxAnalyser.readOpcPackage error handling: it should wrap
+ * POI's NotOfficeXmlFileException/InvalidFormatException into ExcelCommonException
+ * with a message containing "Invalid OOXML/zip format".
+ */
+public class XlsxSaxAnalyserReadOpcPackageTest {
+
+    @Test
+    void invalidInputStream_mandatoryUseInputStream_throwsExcelCommonException() {
+        ReadWorkbook rw = new ReadWorkbook();
+        rw.setInputStream(new ByteArrayInputStream("not-xlsx".getBytes(StandardCharsets.UTF_8)));
+        rw.setMandatoryUseInputStream(true);
+        XlsxReadContext ctx = new DefaultXlsxReadContext(rw, ExcelTypeEnum.XLSX);
+
+        ExcelCommonException ex = assertThrows(ExcelCommonException.class, () -> new XlsxSaxAnalyser(ctx, null));
+        assertTrue(ex.getMessage() != null && ex.getMessage().toLowerCase().contains("invalid ooxml/zip format"));
+    }
+
+    @Test
+    void invalidFile_throwsExcelCommonException() throws Exception {
+        File tmp = File.createTempFile("invalid-ooxml", ".xlsx");
+        try {
+            Files.write(tmp.toPath(), new byte[] {1, 2, 3, 4});
+            ReadWorkbook rw = new ReadWorkbook();
+            rw.setFile(tmp);
+            XlsxReadContext ctx = new DefaultXlsxReadContext(rw, ExcelTypeEnum.XLSX);
+
+            ExcelCommonException ex = assertThrows(ExcelCommonException.class, () -> new XlsxSaxAnalyser(ctx, null));
+            assertTrue(ex.getMessage() != null && ex.getMessage().toLowerCase().contains("invalid ooxml/zip format"));
+        } finally {
+            try {
+                Files.deleteIfExists(tmp.toPath());
+            } catch (Exception ignore) {
+            }
+        }
+    }
+
+    @Test
+    void decryptedStreamProvided_throwsExcelCommonException() {
+        ReadWorkbook rw = new ReadWorkbook();
+        // do not set file/inputStream; pass decryptedStream directly
+        XlsxReadContext ctx = new DefaultXlsxReadContext(rw, ExcelTypeEnum.XLSX);
+        ByteArrayInputStream decrypted = new ByteArrayInputStream("still-not-xlsx".getBytes(StandardCharsets.UTF_8));
+
+        ExcelCommonException ex = assertThrows(ExcelCommonException.class, () -> new XlsxSaxAnalyser(ctx, decrypted));
+        assertTrue(ex.getMessage() != null && ex.getMessage().toLowerCase().contains("invalid ooxml/zip format"));
+    }
+
+    @Test
+    void emptyZipFile_throwsExcelCommonException() throws Exception {
+        File tmp = File.createTempFile("empty-zip", ".xlsx");
+        try (FileOutputStream fos = new FileOutputStream(tmp);
+                ZipOutputStream zos = new ZipOutputStream(fos)) {
+            // write an empty zip with no entries
+        }
+        try {
+            ReadWorkbook rw = new ReadWorkbook();
+            rw.setFile(tmp);
+            XlsxReadContext ctx = new DefaultXlsxReadContext(rw, ExcelTypeEnum.XLSX);
+            ExcelCommonException ex = assertThrows(ExcelCommonException.class, () -> new XlsxSaxAnalyser(ctx, null));
+            assertTrue(ex.getMessage() != null && ex.getMessage().toLowerCase().contains("invalid ooxml/zip format"));
+        } finally {
+            try {
+                Files.deleteIfExists(tmp.toPath());
+            } catch (Exception ignore) {
+            }
+        }
+    }
+
+    @Test
+    void inputStream_nonMandatoryUseTempFileBranch_throwsExcelCommonException() {
+        ReadWorkbook rw = new ReadWorkbook();
+        rw.setInputStream(new ByteArrayInputStream("not-xlsx".getBytes(StandardCharsets.UTF_8)));
+        // mandatoryUseInputStream unset or false -> will write to temp file and then open
+        rw.setMandatoryUseInputStream(false);
+        XlsxReadContext ctx = new DefaultXlsxReadContext(rw, ExcelTypeEnum.XLSX);
+
+        ExcelCommonException ex = assertThrows(ExcelCommonException.class, () -> new XlsxSaxAnalyser(ctx, null));
+        assertTrue(ex.getMessage() != null && ex.getMessage().toLowerCase().contains("invalid ooxml/zip format"));
+    }
+}

--- a/fastexcel/src/test/java/cn/idev/excel/fuzz/ExcelReadFuzzTest.java
+++ b/fastexcel/src/test/java/cn/idev/excel/fuzz/ExcelReadFuzzTest.java
@@ -1,4 +1,4 @@
-package cn.idev.excel.test.fuzz;
+package cn.idev.excel.fuzz;
 
 import cn.idev.excel.FastExcelFactory;
 import cn.idev.excel.read.builder.ExcelReaderBuilder;

--- a/fastexcel/src/test/java/cn/idev/excel/test/fuzz/ExcelReadFuzzTest.java
+++ b/fastexcel/src/test/java/cn/idev/excel/test/fuzz/ExcelReadFuzzTest.java
@@ -1,0 +1,44 @@
+package cn.idev.excel.test.fuzz;
+
+import cn.idev.excel.FastExcelFactory;
+import cn.idev.excel.read.builder.ExcelReaderBuilder;
+import com.code_intelligence.jazzer.junit.FuzzTest;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import lombok.SneakyThrows;
+
+/**
+ * Fuzzes the generic read path with arbitrary bytes to discover parsing issues.
+ */
+public class ExcelReadFuzzTest {
+
+    private static final int MAX_SIZE = 1_000_000; // 1MB guard to avoid OOM / long loops
+
+    @SneakyThrows
+    @FuzzTest
+    void fuzzRead(byte[] data) {
+        if (data == null || data.length == 0 || data.length > MAX_SIZE) {
+            return; // Ignore trivial or oversized inputs
+        }
+        try (InputStream in = new ByteArrayInputStream(data)) {
+            ExcelReaderBuilder builder = FastExcelFactory.read(in);
+            // Always attempt to read first sheet synchronously if possible
+            builder.sheet().doReadSync();
+        } catch (Throwable t) {
+            // Jazzer treats uncaught exceptions as findings. We allow RuntimeExceptions that
+            // indicate expected format errors, but still surface anything else.
+            // Swallow common benign exceptions to reduce noise.
+            String msg = t.getMessage();
+            if (msg != null) {
+                String lower = msg.toLowerCase();
+                if (lower.contains("invalid")
+                        || lower.contains("zip")
+                        || lower.contains("format")
+                        || lower.contains("end of central directory")) {
+                    return; // expected parse/format issues
+                }
+            }
+            throw t;
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project
-    xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+        xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
 >
     <modelVersion>4.0.0</modelVersion>
 
@@ -51,8 +51,8 @@
         <mockito.version>4.11.0</mockito.version>
         <surefire.jvm.args>-Xmx2g -Xms2g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8</surefire.jvm.args>
         <surefire.jdk9plus.args></surefire.jdk9plus.args>
+        <jazzer.junit.version>0.25.0</jazzer.junit.version>
         <argLine></argLine>
-
     </properties>
 
     <scm>
@@ -205,6 +205,34 @@
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-junit-jupiter</artifactId>
                 <version>${mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.code-intelligence</groupId>
+                <artifactId>jazzer-junit</artifactId>
+                <version>${jazzer.junit.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-engine</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-params</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-launcher</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-commons</artifactId>
+                    </exclusion>
+                </exclusions>
                 <scope>test</scope>
             </dependency>
 
@@ -422,17 +450,17 @@
                         <importOrder>
                             <order>\#|</order>
                         </importOrder>
-                        <removeUnusedImports />
-                        <trimTrailingWhitespace />
-                        <endWithNewline />
+                        <removeUnusedImports/>
+                        <trimTrailingWhitespace/>
+                        <endWithNewline/>
                         <indent>
                             <spaces>true</spaces>
                             <spacesPerTab>4</spacesPerTab>
                         </indent>
                     </java>
                     <pom>
-                        <trimTrailingWhitespace />
-                        <endWithNewline />
+                        <trimTrailingWhitespace/>
+                        <endWithNewline/>
                         <indent>
                             <spaces>true</spaces>
                             <spacesPerTab>4</spacesPerTab>
@@ -472,7 +500,8 @@
             <properties>
                 <surefire.jdk9plus.args>--add-opens=java.base/java.lang=ALL-UNNAMED
                     --add-opens=java.base/java.util=ALL-UNNAMED
-                    --add-opens=java.base/sun.reflect.annotation=ALL-UNNAMED</surefire.jdk9plus.args>
+                    --add-opens=java.base/sun.reflect.annotation=ALL-UNNAMED
+                </surefire.jdk9plus.args>
             </properties>
         </profile>
         <profile>
@@ -481,7 +510,7 @@
                 <jdk>1.8</jdk>
             </activation>
             <properties>
-                <surefireArgLine> -Dfile.encoding=UTF-8</surefireArgLine>
+                <surefireArgLine>-Dfile.encoding=UTF-8</surefireArgLine>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
<!--
Thanks very much for contributing to FastExcel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

Closed: #ISSUE
Related: #ISSUE

-->

## Purpose of the pull request

add fuzz testing for Excel reading and improve error handling in XlsxSaxAnalyser
Related: #521 #548 #550
## What's changed?

Before
<img width="1218" height="445" alt="image" src="https://github.com/user-attachments/assets/7c6f7dd7-9208-4705-8a6f-88dc33636f22" />
<img width="1527" height="416" alt="image" src="https://github.com/user-attachments/assets/1dbed7f4-34fb-4ad4-adb0-7704c2170bb1" />

After
<img width="1202" height="370" alt="image" src="https://github.com/user-attachments/assets/96b9b690-e07f-42b8-87b5-067cecf62c7c" />
<img width="823" height="437" alt="image" src="https://github.com/user-attachments/assets/e1a1652c-f234-4e58-ac9c-1bf492364909" />


## Checklist

- [X] I have read the [Contributor Guide](https://fast-excel.github.io/fastexcel/community/contribution).
- [X] I have written the necessary doc or comment.
- [X] I have added the necessary unit tests and all cases have passed.
