### PR TITLE
feat: handle very old Excel BIFF formats gracefully with no-op executor

### DIFF
--- a/fastexcel/src/test/java/cn/idev/excel/analysis/ExcelAnalyserOldBiffTest.java
+++ b/fastexcel/src/test/java/cn/idev/excel/analysis/ExcelAnalyserOldBiffTest.java
@@ -1,0 +1,72 @@
+package cn.idev.excel.analysis;
+
+import cn.idev.excel.read.metadata.ReadWorkbook;
+import cn.idev.excel.support.ExcelTypeEnum;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+import java.util.Collections;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Unit tests for handling very old XLS (e.g., BIFF2) gracefully.
+ */
+class ExcelAnalyserOldBiffTest {
+
+    /**
+     * Given a BIFF2-like minimal input (from fuzz crash seed Base64: CQAE),
+     * ExcelAnalyserImpl should not throw; it should fall back to a no-op executor.
+     */
+    @Test
+    void chooseExecutor_shouldNoop_onOldBiffBytes_stream() {
+        byte[] seed = Base64.getDecoder().decode("CQAE");
+        InputStream in = new ByteArrayInputStream(seed);
+
+        ReadWorkbook rw = new ReadWorkbook();
+        rw.setInputStream(in);
+        // Force XLS branch so chooseExcelExecutor will attempt POIFS construction
+        rw.setExcelType(ExcelTypeEnum.XLS);
+
+        ExcelAnalyserImpl analyser = new ExcelAnalyserImpl(rw);
+        // analysis should not throw even if sheets list is empty when readAll=true
+        Assertions.assertDoesNotThrow(() -> analyser.analysis(Collections.emptyList(), true));
+        // Noop executor should present empty sheet list
+        Assertions.assertTrue(analyser.excelExecutor().sheetList().isEmpty());
+        // Analysis context should be XLS (fallback context)
+        Assertions.assertEquals(
+                ExcelTypeEnum.XLS,
+                analyser.analysisContext().readWorkbookHolder().getExcelType());
+        Assertions.assertTrue(
+                analyser.excelExecutor() instanceof ExcelAnalyserImpl.NoopExcelReadExecutor,
+                "Executor should be NoopExcelReadExecutor for old BIFF");
+    }
+
+    /**
+     * Same as above but via File path to cover the other constructor branch.
+     */
+    @Test
+    void chooseExecutor_shouldNoop_onOldBiffBytes_file(@TempDir Path tmp) throws Exception {
+        byte[] seed = Base64.getDecoder().decode("CQAE");
+        Path f = tmp.resolve("old_biff_seed.xls");
+        Files.write(f, seed);
+
+        ReadWorkbook rw = new ReadWorkbook();
+        rw.setFile(f.toFile());
+        // Force XLS branch
+        rw.setExcelType(ExcelTypeEnum.XLS);
+
+        ExcelAnalyserImpl analyser = new ExcelAnalyserImpl(rw);
+        Assertions.assertDoesNotThrow(() -> analyser.analysis(Collections.emptyList(), true));
+        Assertions.assertTrue(analyser.excelExecutor().sheetList().isEmpty());
+        Assertions.assertEquals(
+                ExcelTypeEnum.XLS,
+                analyser.analysisContext().readWorkbookHolder().getExcelType());
+        Assertions.assertTrue(
+                analyser.excelExecutor() instanceof ExcelAnalyserImpl.NoopExcelReadExecutor,
+                "Executor should be NoopExcelReadExecutor for old BIFF");
+    }
+}

--- a/fastexcel/src/test/java/cn/idev/excel/fuzz/XlsReadFuzzTest.java
+++ b/fastexcel/src/test/java/cn/idev/excel/fuzz/XlsReadFuzzTest.java
@@ -1,0 +1,65 @@
+package cn.idev.excel.fuzz;
+
+import cn.idev.excel.FastExcelFactory;
+import cn.idev.excel.read.builder.ExcelReaderBuilder;
+import cn.idev.excel.support.ExcelTypeEnum;
+import com.code_intelligence.jazzer.junit.FuzzTest;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.zip.ZipException;
+import lombok.SneakyThrows;
+import org.apache.poi.EmptyFileException;
+import org.apache.poi.hssf.record.RecordInputStream.LeftoverDataException;
+import org.apache.poi.poifs.filesystem.NotOLE2FileException;
+import org.apache.poi.poifs.filesystem.OfficeXmlFileException;
+
+/**
+ * Fuzzes the XLS (BIFF) parsing path with arbitrary bytes.
+ */
+public class XlsReadFuzzTest {
+    private static final int MAX_SIZE = 1_000_000; // 1MB guard
+
+    @SneakyThrows
+    @FuzzTest
+    void fuzzXls(byte[] data) {
+        if (data == null || data.length == 0 || data.length > MAX_SIZE) {
+            return;
+        }
+        try (InputStream in = new ByteArrayInputStream(data)) {
+            ExcelReaderBuilder builder = FastExcelFactory.read(in).excelType(ExcelTypeEnum.XLS);
+            builder.sheet().doReadSync();
+        } catch (Throwable t) {
+            if (isBenignHssfParseException(t)) {
+                return; // expected for random inputs
+            }
+            throw t;
+        }
+    }
+
+    private static boolean isBenignHssfParseException(Throwable t) {
+        for (int i = 0; i < 6 && t != null; i++, t = t.getCause()) {
+            if (t instanceof NotOLE2FileException
+                    || t instanceof OfficeXmlFileException
+                    || t instanceof LeftoverDataException
+                    || t instanceof EmptyFileException
+                    || t instanceof ZipException) {
+                return true;
+            }
+            String msg = t.getMessage();
+            if (msg != null) {
+                String m = msg.toLowerCase();
+                if (m.contains("not ole2")
+                        || m.contains("invalid header signature")
+                        || m.contains("corrupt stream")
+                        || m.contains("invalid record")
+                        || m.contains("buffer underrun")
+                        || m.contains("buffer overrun")
+                        || m.contains("leftover")
+                        || m.contains("zip")) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
<!--
Thanks very much for contributing to FastExcel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

Closed: #ISSUE
Related: #ISSUE

-->

## Purpose of the pull request
handle very old Excel BIFF formats gracefully with no-op executor

Related: #558 #521 

## What's changed?


Before
<img width="1842" height="449" alt="image" src="https://github.com/user-attachments/assets/fd5d0e0d-c009-48e2-ad51-ef824e17a422" />


After
<img width="1834" height="551" alt="image" src="https://github.com/user-attachments/assets/aaf2c65b-02f1-4b28-96f0-015b22f2e9ca" />

Even the error message mentioned the usage of "OldExcelExtractor", but it won't fulfill the basic requirement. As BIFF2 for Excel 2.0 (1987), so just skip the hint with an alternative solution.

reference:
https://www.ibm.com/docs/en/personal-communications/13.0.0?topic=types-biff-files

## Checklist

- [X] I have read the [Contributor Guide](https://fast-excel.github.io/fastexcel/community/contribution).
- [X] I have written the necessary doc or comment.
- [X] I have added the necessary unit tests and all cases have passed.
